### PR TITLE
chore(std): publish v0.0.5

### DIFF
--- a/packages/std/README.md
+++ b/packages/std/README.md
@@ -59,7 +59,7 @@ This library has a few main goal:
 
 **fp-ts**:
 
-This library has been heavily inspired by `fp-ts`, and has re-implemented a lot of useful concepts (Results, Tasks, Decoders, Option, Ord, pipe, etc...)
+This library has been heavily inspired by `fp-ts`, and has re-implemented a lot of useful concepts (Results, Tasks, Option, Ord, pipe, etc...)
 
 However, `fp-ts` is unfortunaly too complicated to use and doesn't always integrate well with existing code.
 As such, while this library may have a few similarities, `@apoyo/std` has been heavily simplified for easier usage.

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/std",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Typescript utility library",
   "main": "lib/index.js",
   "module": "es6/index.js",
@@ -24,9 +24,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/neoxia/apoyo-std"
+    "url": "https://github.com/neoxia/apoyo"
   },
-  "homepage": "https://nx-apoyo.netlify.app/",
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/std",
   "scripts": {
     "test": "npx jest --clearCache && jest --verbose --runInBand",
     "clean": "npx rimraf ./dist",


### PR DESCRIPTION
**Breaking changes**:

- Move Decode, DecodeError and TaskDecode into @apoyo/decoders package.