### PR TITLE
RFC: feat(ioc): create ioc package for easy dependency management

### DIFF
--- a/examples/ioc/example.ts
+++ b/examples/ioc/example.ts
@@ -1,0 +1,94 @@
+import { Container, Service } from '@apoyo/ioc'
+
+const Env = Service.factory('Env', [], async () => {
+  return {
+    API_PORT: 8080,
+    DATABASE_URL: 'xxxxx'
+  }
+})
+
+const Config = Service.factory('Config', [Env], async (env) => {
+  return {
+    api: {
+      port: env.API_PORT
+    },
+    database: {
+      url: env.DATABASE_URL
+    }
+  }
+})
+
+// Split a big service into multiple smaller services (1 per property)
+// This allows features to be more easily tested
+const Configs = Service.pluckAll(Config)
+
+const Database = Service.factory('Database', [Configs.database], (config) => {
+  // for demo-purposes, use real implementation in real use-cases
+  const createPool = (config: any) => {
+    return {
+      config,
+      destroy: () => Promise.resolve()
+    }
+  }
+
+  // create pool
+  const pool = createPool(config)
+
+  return Service.result(pool, {
+    onDestroy: async () => {
+      console.log(`Close database`)
+      await pool.destroy()
+    }
+  })
+})
+
+const Api = Service.factory('Api', [Configs.api, Database], async (apiConfig) => {
+  const server = { apiConfig, close: () => Promise.resolve() }
+
+  console.log(`Start Api`)
+  setTimeout(() => ({}), 10000)
+
+  return Service.result(server, {
+    onDestroy: async () => {
+      console.log(`Close server`)
+      await server.close()
+    }
+  })
+})
+
+const main = async () => {
+  // Create mocks
+  const Mocks = {
+    ApiConfig: Service.constant('Mocks.ApiConfig', {
+      port: 9090
+    })
+  }
+
+  // Setup root services, all child dependencies will be loaded automatically
+  const app = await Container.bootstrap({
+    services: [Api],
+    bindings: [Service.bind(Configs.api, Mocks.ApiConfig)]
+  })
+
+  console.log(`Application started`)
+
+  // Await an exit signal
+  await new Promise((resolve) => {
+    process.once('exit', resolve)
+    process.once('uncaughtException', resolve)
+    process.once('unhandledRejection', resolve)
+    process.once('SIGTERM', resolve)
+    process.once('SIGINT', resolve)
+    process.once('SIGUSR1', resolve)
+    process.once('SIGUSR2', resolve)
+  })
+
+  console.log(`Stopping services...`)
+
+  // Teardown all mounted services
+  await Container.destroy(app)
+
+  console.log(`Exiting application`)
+}
+
+main()

--- a/packages/ioc/CHANGELOG.md
+++ b/packages/ioc/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/ioc/LICENSE
+++ b/packages/ioc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/ioc/README.md
+++ b/packages/ioc/README.md
@@ -1,0 +1,129 @@
+# Apoyo - IoC
+
+[![npm version](https://badgen.net/npm/v/@apoyo/ioc)](https://www.npmjs.com/package/@apoyo/ioc)
+[![build size](https://badgen.net/bundlephobia/min/@apoyo/ioc)](https://bundlephobia.com/result?p=@apoyo/ioc)
+[![three shaking](https://badgen.net/bundlephobia/tree-shaking/@apoyo/ioc)](https://bundlephobia.com/result?p=@apoyo/ioc)
+
+**Warning**: This package is still in development and features may still change, be renamed or removed.
+
+However, we would appreciate any feedback you have on how to improve this library:
+
+- Which features are missing?
+- Which features are hard to understand or unnecessary?
+- Which features need to be improved?
+
+## Installation
+
+**Warning**: This package has not been deployed to NPM yet and may still be renamed.
+
+`npm install @apoyo/ioc`
+
+## Description
+
+Ths package contains utilities to setup and manage projects:
+
+- Class-less service creation
+- Dependencies management
+- Service binding and mocking
+- Async setup & teardown support
+
+The main goal of this package is to provide a progressive solution that is easily integrated in an existing projects / non-Typescript projects without decorators.
+
+## Example
+
+```ts
+
+import { Container, Service } from '@apoyo/ioc'
+
+const Env = Service.factory('Env', [], async () => {
+  return {
+    API_PORT: 8080,
+    DATABASE_URL: 'xxxxx'
+  }
+})
+
+const Config = Service.factory('Config', [Env], async (env) => {
+  return {
+    api: {
+      port: env.API_PORT
+    },
+    database: {
+      url: env.DATABASE_URL
+    }
+  }
+})
+
+// Split a big service into multiple smaller services (1 per property)
+// This allows features to be more easily tested
+const Configs = Service.pluckAll(Config)
+
+const Database = Service.factory('Database', [Configs.database], (config) => {
+  // for demo-purposes, use real implementation in real use-cases
+  const createPool = (config: any) => {
+    return {
+      config,
+      destroy: () => Promise.resolve()
+    }
+  }
+
+  // create pool
+  const pool = createPool(config)
+
+  return Service.result(pool, {
+    onDestroy: async () => {
+      console.log(`Close database`)
+      await pool.destroy()
+    }
+  })
+})
+
+const Api = Service.factory('Api', [Configs.api, Database], async (apiConfig) => {
+  const server = { apiConfig, close: () => Promise.resolve() }
+
+  console.log(`Start Api`)
+
+  return Service.result(server, {
+    onDestroy: async () => {
+      console.log(`Close server`)
+      await server.close()
+    }
+  })
+})
+
+const main = async () => {
+  // Create mocks
+  const Mocks = {
+    ApiConfig: Service.constant('Mocks.ApiConfig', {
+      port: 9090
+    })
+  }
+
+  // Setup root services, all child dependencies will be loaded automatically
+  const app = await Container.bootstrap({
+    services: [Api],
+    bindings: [Service.bind(Configs.api, Mocks.ApiConfig)]
+  })
+
+  console.log(`Application started`)
+
+  // Await an exit signal
+  await new Promise((resolve) => {
+    process.once('exit', resolve)
+    process.once('uncaughtException', resolve)
+    process.once('unhandledRejection', resolve)
+    process.once('SIGTERM', resolve)
+    process.once('SIGINT', resolve)
+    process.once('SIGUSR1', resolve)
+    process.once('SIGUSR2', resolve)
+  })
+
+  console.log(`Stopping services...`)
+
+  // Teardown all mounted services
+  await Container.destroy(app)
+
+  console.log(`Exiting application`)
+}
+
+main()
+```

--- a/packages/ioc/jest.config.js
+++ b/packages/ioc/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/ioc/package.json
+++ b/packages/ioc/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@apoyo/ioc",
+  "private":"true",
+  "version": "0.0.1",
+  "description": "IoC utilities",
+  "main": "lib/index.js",
+  "module": "es6/index.js",
+  "typings": "lib/index.d.ts",
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "tags": [
+    "utils",
+    "services",
+    "dependencies",
+    "typescript"
+  ],
+  "keywords": [
+    "utils",
+    "services",
+    "dependencies",
+    "typescript"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/ioc",
+  "scripts": {
+    "test": "npx jest --clearCache && jest --verbose --runInBand",
+    "clean": "npx rimraf ./dist",
+    "prebuild": "npm run clean",
+    "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
+  },
+  "dependencies": {
+    "@apoyo/decoders": "^0.0.3",
+    "@apoyo/std": "^0.0.5"
+  },
+  "devDependencies": {
+    "@types/jest": "22.2.2",
+    "@types/node": "^12.6.8",
+    "jest": "^26.4.2",
+    "rimraf": "2.6.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "typescript": "^4.1.2"
+  }
+}

--- a/packages/ioc/src/Container.ts
+++ b/packages/ioc/src/Container.ts
@@ -1,0 +1,89 @@
+import { Arr, Err, pipe } from '@apoyo/std'
+import { Service } from './Service'
+
+export type Container = {
+  bindings: Map<Service.Factory, Service.Binding>
+  services: Map<Service.Factory, Service>
+}
+
+export type ContainerOptions = {
+  bindings?: Service.Binding[]
+  services: Service.Factory[]
+}
+
+export const getBindingOf = <T>(container: Container, factory: Service.Factory<T>): Service.Factory<T> => {
+  const binding = container.bindings.get(factory) as Service.Factory<T> | undefined
+  if (binding) {
+    return getBindingOf(container, binding)
+  }
+  return factory
+}
+
+export const getInterfaceOf = <T>(
+  container: Container,
+  factory: Service.Factory<T>
+): Service.Factory<T> | undefined => {
+  if (Service.isBinding(factory)) {
+    return getInterfaceOf(container, factory.implements)
+  }
+  return undefined
+}
+
+export const bootstrap = async (options: ContainerOptions): Promise<Container> => {
+  const bindings = pipe(
+    options.bindings || [],
+    Arr.map((b) => [b.implements, b] as const)
+  )
+
+  const container: Container = {
+    bindings: new Map(bindings),
+    services: new Map()
+  }
+
+  try {
+    for (const service of options.services) {
+      await Service.mount(container, service)
+    }
+  } catch (err) {
+    await destroy(container)
+    throw pipe(err, Err.chain(`An error occured while bootstrapping the container`))
+  }
+  return container
+}
+
+export const findService = <T>(container: Container, factory: Service.Factory<T>): Service<T> | undefined =>
+  container.services.get(getBindingOf(container, factory)) as Service<T> | undefined
+
+export const find = async <T>(app: Container, setup: Service.Factory<T>) => {
+  const service = findService(app, setup)
+  if (!service) {
+    throw Err.of(`Could not find service "${setup.name}". Are you sure this service has been loaded?`)
+  }
+  if (!service.body) {
+    throw Err.of(`This service has been created, but has not finished loading yet.`)
+  }
+  return service.body as Promise<T>
+}
+
+export const destroy = async (container: Container): Promise<void> => {
+  try {
+    const root = pipe(
+      Arr.from(container.services.values()),
+      Arr.filter((service) => service.dependents.length === 0)
+    )
+    for (const service of root) {
+      await Service.unmountDeep(service)
+    }
+  } catch (err) {
+    throw pipe(err, Err.chain(`An error occured while shutting down the container`))
+  }
+}
+
+export const Container = {
+  getBindingOf,
+  getInterfaceOf,
+  bootstrap,
+  destroy,
+  findService,
+  find
+}

--- a/packages/ioc/src/Service.ts
+++ b/packages/ioc/src/Service.ts
@@ -1,0 +1,327 @@
+import { Arr, Dict, Err, pipe, Prom, Task } from '@apoyo/std'
+import { Container } from './Container'
+
+const enum Tags {
+  ServiceResult = 'Service.Result'
+}
+
+export type Service<T = unknown> = {
+  container: Container
+  factory: Service.Factory<T>
+  dependencies: Service[]
+  dependents: Service[]
+  onDestroy?: Task<void>
+  body?: Promise<T>
+}
+
+export const enum ServiceErrors {
+  InitError = 'ServiceInitError',
+  DestroyError = 'ServiceDestroyError'
+}
+
+export namespace Service {
+  export type TypeOf<T extends Service.Factory> = T extends Service.Factory<infer A> ? A : never
+
+  export interface Result<T> {
+    _tag: Tags.ServiceResult
+    value: T
+    onDestroy?: Task<void>
+  }
+
+  export type Return<T> = Promise<Result<T>> | Promise<T> | Result<T> | T
+
+  export interface Factory<T = any, Args extends any[] = any[]> {
+    name: string
+    dependencies: Factory[]
+    factory: (...args: Args) => Return<T>
+  }
+
+  export interface Binding<T = any> extends Factory<T> {
+    implements: Factory<T>
+  }
+}
+
+export function factory<T>(name: string, dependencies: [], fn: () => Service.Return<T>): Service.Factory<T, []>
+export function factory<A, T>(
+  name: string,
+  dependencies: [Service.Factory<A>],
+  fn: (a: A) => Service.Return<T>
+): Service.Factory<T, [A]>
+export function factory<A, B, T>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>],
+  fn: (a: A, b: B) => Service.Return<T>
+): Service.Factory<T, [A, B]>
+export function factory<A, B, C, T>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>],
+  fn: (a: A, b: B, c: C) => Service.Return<T>
+): Service.Factory<T, [A, B, C]>
+export function factory<A, B, C, D, T>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>, Service.Factory<D>],
+  fn: (a: A, b: B, c: C, d: D) => Service.Return<T>
+): Service.Factory<T, [A, B, C, D]>
+export function factory<A, B, C, D, E, T>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>, Service.Factory<D>, Service.Factory<E>],
+  fn: (a: A, b: B, c: C, d: D, e: E) => Service.Return<T>
+): Service.Factory<T, [A, B, C, D, E]>
+export function factory<A, B, C, D, E, F, T>(
+  name: string,
+  dependencies: [
+    Service.Factory<A>,
+    Service.Factory<B>,
+    Service.Factory<C>,
+    Service.Factory<D>,
+    Service.Factory<E>,
+    Service.Factory<F>
+  ],
+  fn: (a: A, b: B, c: C, d: D, e: E, f: F) => Service.Return<T>
+): Service.Factory<T, [A, B, C, D, E, F]>
+export function factory(
+  name: string,
+  dependencies: Service.Factory[],
+  fn: (...args: unknown[]) => Service.Return<unknown>
+): Service.Factory {
+  return {
+    name,
+    dependencies,
+    factory: fn
+  }
+}
+
+export const abstract = <T>(name: string): Service.Factory<T> =>
+  factory<T>(name, [], () => Prom.reject(Err.of(`Service "${name}" has not been implemented`)))
+
+export function combine<A>(name: string, dependencies: [Service.Factory<A>]): Service.Factory<[A]>
+export function combine<A, B>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>]
+): Service.Factory<[A, B]>
+export function combine<A, B, C>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>]
+): Service.Factory<[A, B, C]>
+export function combine<A, B, C, D>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>, Service.Factory<D>]
+): Service.Factory<[A, B, C, D]>
+export function combine<A, B, C, D, E>(
+  name: string,
+  dependencies: [Service.Factory<A>, Service.Factory<B>, Service.Factory<C>, Service.Factory<D>, Service.Factory<E>]
+): Service.Factory<[A, B, C, D, E]>
+export function combine<A, B, C, D, E, F>(
+  name: string,
+  dependencies: [
+    Service.Factory<A>,
+    Service.Factory<B>,
+    Service.Factory<C>,
+    Service.Factory<D>,
+    Service.Factory<E>,
+    Service.Factory<F>
+  ]
+): Service.Factory<[A, B, C, D, E, F]>
+export function combine(name: string, dependencies: Service.Factory[]): Service.Factory
+export function combine(name: string, dependencies: Service.Factory[]): Service.Factory {
+  return {
+    name,
+    dependencies,
+    factory: (...args) => args
+  }
+}
+
+export const constant = <T>(name: string, value: T): Service.Factory<T, []> => factory(name, [], () => value)
+
+export const pluck = <T extends object, U extends keyof T>(
+  factory: Service.Factory<T>,
+  key: U
+): Service.Factory<T[U]> => Service.factory(`${factory.name}.${key}`, [factory], (value) => value[key])
+
+export const pluckAll = <T extends object>(
+  factory: Service.Factory<T>
+): {
+  [P in keyof T]: Service.Factory<T[P]>
+} => {
+  const target: Dict<Service.Factory> = {}
+  const proxy = new Proxy(target, {
+    get(target, prop: string) {
+      const plucked = target[prop]
+      if (plucked) {
+        return plucked
+      }
+      target[prop] = pluck(factory, prop as keyof T)
+      return target[prop]
+    }
+  })
+  return proxy as any
+}
+
+export const bind = <T, U extends T>(from: Service.Factory<T>, to: Service.Factory<U>): Service.Binding<T> => ({
+  ...to,
+  implements: from
+})
+
+export const result = <T>(value: T, options: { onDestroy?: Task<void> } = {}): Service.Result<T> => ({
+  _tag: Tags.ServiceResult,
+  value,
+  onDestroy: options.onDestroy
+})
+
+export const isBinding = <T>(factory: Service.Factory<T>): factory is Service.Binding<T> =>
+  (factory as any).implements !== undefined
+
+export const isResult = <T>(factory: T | Service.Result<T>): factory is Service.Result<T> =>
+  (factory as any)._tag === Tags.ServiceResult
+
+export const isDependencyRegistered = (parent: Service, dependency: Service) =>
+  !!parent.dependencies.find((d) => d === dependency)
+
+export const isInitError = Err.hasName(ServiceErrors.InitError)
+
+export const getLabel = (service: Service) => {
+  const implFactory = service.factory
+  const interfaceFactory = Container.getInterfaceOf(service.container, implFactory)
+  return interfaceFactory ? `${implFactory.name} (implements ${interfaceFactory.name})` : implFactory.name
+}
+
+export const getLatestPath = (service: Service): string => {
+  const label = getLabel(service)
+  const parent = pipe(service.dependents, Arr.last)
+  return parent ? `${getLatestPath(parent)} → ${label}` : `<root> → ${label}`
+}
+
+export const createInitError = (service: Service, err: unknown) => {
+  if (isInitError(err)) {
+    return err
+  }
+  const component = service.factory
+  const path = getLatestPath(service)
+  const message = `Could not initialize service "${component.name}" at ${path}`
+  return pipe(
+    err,
+    Err.chain(message, {
+      name: ServiceErrors.InitError
+    })
+  )
+}
+
+export const create = <T>(container: Container, factory: Service.Factory<T>, parent?: Service): Service<T> => {
+  const bound = Container.getBindingOf(container, factory)
+  if (bound !== factory) {
+    return create(container, bound, parent)
+  }
+
+  const existing = container.services.get(factory) as Service<T> | undefined
+  if (existing) {
+    if (parent && !isDependencyRegistered(parent, existing)) {
+      parent.dependencies.push(existing)
+      existing.dependents.push(parent)
+    }
+    return existing
+  }
+
+  const module: Service<T> = {
+    container: container,
+    factory: factory,
+    dependencies: [],
+    dependents: []
+  }
+
+  if (parent) {
+    parent.dependencies.push(module)
+    module.dependents.push(parent)
+  }
+  container.services.set(factory, module)
+
+  for (const dep of factory.dependencies) {
+    create(container, dep, module)
+  }
+
+  return module
+}
+
+export const instantiate = async <Args extends any[], T>(factory: Service.Factory<T, Args>, ...args: Args) => {
+  const data = await factory.factory(...args)
+  return isResult(data) ? data : Service.result(data)
+}
+
+export const get = <T>(service: Service<T>): Promise<T> => {
+  if (service.body) {
+    return service.body
+  }
+  const factory = service.factory
+  service.body = pipe(
+    service.dependencies,
+    Arr.map(get),
+    Prom.all,
+    Prom.chain(async (deps) => {
+      const result = await instantiate(factory, ...deps)
+      service.onDestroy = result.onDestroy
+      return result.value
+    }),
+    Prom.mapError((err) => createInitError(service, err))
+  )
+  return service.body
+}
+
+export const mount = async <T>(container: Container, factory: Service.Factory<T>, parent?: Service): Promise<T> =>
+  pipe(create(container, factory, parent), get)
+
+export const unmount = async (service: Service) => {
+  try {
+    if (service.dependents.length > 0) {
+      throw Err.of(`Cannot unmount service with dependents. Please unmount the dependents first`)
+    }
+    if (service.body) {
+      await Prom.tryCatch(service.body)
+      service.body = undefined
+    }
+    if (service.onDestroy) {
+      await service.onDestroy()
+      service.onDestroy = undefined
+    }
+    for (const dep of service.dependencies) {
+      dep.dependents = dep.dependents.filter((parent) => parent !== service)
+    }
+    service.container.services.delete(service.factory)
+  } catch (err) {
+    throw pipe(
+      err,
+      Err.chain(`Could not unmount service "${service.factory.name}"`, {
+        name: ServiceErrors.DestroyError
+      })
+    )
+  }
+}
+
+export const unmountDeep = async (module: Service) => {
+  await unmount(module)
+  const unused = module.dependencies.filter((d) => d.dependents.length === 0)
+  for (const dep of unused) {
+    await unmountDeep(dep)
+  }
+}
+
+export const Service = {
+  factory,
+  abstract,
+  constant,
+  combine,
+  pluck,
+  pluckAll,
+  bind,
+  result,
+
+  isBinding,
+  isDependencyRegistered,
+  getLabel,
+  getLatestPath,
+
+  create,
+  get,
+  instantiate,
+  mount,
+  unmount,
+  unmountDeep
+}

--- a/packages/ioc/src/index.ts
+++ b/packages/ioc/src/index.ts
@@ -1,0 +1,2 @@
+export { Service, ServiceErrors } from './Service'
+export { Container, ContainerOptions } from './Container'

--- a/packages/ioc/tests/Container.spec.ts
+++ b/packages/ioc/tests/Container.spec.ts
@@ -1,0 +1,154 @@
+import { pipe, Prom, Result } from '@apoyo/std'
+import { Container, Service } from '../src'
+
+const Env = Service.factory('Env', [], async () => {
+  return {
+    API_PORT: 8080
+  }
+})
+
+const Config = Service.factory('Config', [Env], async (env) => {
+  return {
+    api: {
+      port: env.API_PORT
+    }
+  }
+})
+
+const ApiConfig = Service.factory('Config.api', [Config], (config) => config.api)
+
+const Api = Service.factory('Api', [ApiConfig], async (apiConfig) => {
+  const server = { apiConfig, close: () => Promise.resolve() }
+
+  return Service.result(server, {
+    onDestroy: () => server.close()
+  })
+})
+
+describe('Container.bootstrap', () => {
+  it('should bootstrap all services', async () => {
+    const app = await Container.bootstrap({
+      services: [Api]
+    })
+
+    const apiConfig = await Container.find(app, ApiConfig)
+
+    expect(apiConfig).toEqual({
+      port: 8080
+    })
+
+    await Container.destroy(app)
+
+    expect(app.services.size).toBe(0)
+  })
+
+  it('should bootstrap all services with correct bindings', async () => {
+    const Mocks = {
+      ApiConfig: Service.constant('Mocks.ApiConfig', {
+        port: 9090
+      })
+    }
+
+    const app = await Container.bootstrap({
+      services: [Api],
+      bindings: [Service.bind(ApiConfig, Mocks.ApiConfig)]
+    })
+
+    const config = await Container.find(app, ApiConfig)
+
+    expect(config).toEqual({
+      port: 9090
+    })
+
+    await Container.destroy(app)
+
+    expect(app.services.size).toBe(0)
+  })
+
+  it('should throw on unimplemented error', async () => {
+    const Mocks = {
+      Env: Service.abstract<any>('TestEnv')
+    }
+
+    const result = await pipe(
+      Container.bootstrap({
+        services: [Api],
+        bindings: [Service.bind(Env, Mocks.Env)]
+      }),
+      Prom.tryCatch
+    )
+
+    const error = Result.isKo(result) ? (result.ko as Error) : undefined
+
+    expect(pipe(result, Result.isKo)).toBe(true)
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      `An error occured while bootstrapping the container: Could not initialize service "TestEnv" at <root> → Api → Config.api → Config → TestEnv: Service "TestEnv" has not been implemented`
+    )
+  })
+
+  it('should throw on internal error', async () => {
+    const Mocks = {
+      Env: Service.factory('TestEnv', [], () => {
+        throw new Error('Internal error')
+      })
+    }
+
+    const result = await pipe(
+      Container.bootstrap({
+        services: [Api],
+        bindings: [Service.bind(Env, Mocks.Env)]
+      }),
+      Prom.tryCatch
+    )
+
+    const error = Result.isKo(result) ? (result.ko as Error) : undefined
+
+    expect(pipe(result, Result.isKo)).toBe(true)
+    expect(error).toBeInstanceOf(Error)
+    expect(error?.message).toBe(
+      `An error occured while bootstrapping the container: Could not initialize service "TestEnv" at <root> → Api → Config.api → Config → TestEnv: Internal error`
+    )
+  })
+})
+
+describe('Container.destroy', () => {
+  it('should destroy in correct order', async () => {
+    const mock = jest.fn()
+
+    const A = Service.factory('A', [], () => {
+      return Service.result('A', {
+        onDestroy: () => mock('A')
+      })
+    })
+
+    const B = Service.factory('B', [A], () => {
+      return Service.result('B', {
+        onDestroy: () =>
+          pipe(
+            Prom.thunk(() => mock('B')),
+            Prom.delay(100)
+          )
+      })
+    })
+
+    const C = Service.factory('C', [B], () => {
+      return Service.result('C', {
+        onDestroy: () =>
+          pipe(
+            Prom.thunk(() => mock('C')),
+            Prom.delay(100)
+          )
+      })
+    })
+
+    const app = await Container.bootstrap({
+      services: [C]
+    })
+
+    await Container.destroy(app)
+
+    expect(mock.mock.calls.length).toBe(3)
+    expect(mock.mock.calls).toEqual([['C'], ['B'], ['A']])
+  })
+})

--- a/packages/ioc/tsconfig.common.json
+++ b/packages/ioc/tsconfig.common.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.common.json",
+  "compilerOptions": {
+    "outDir": "./dist/lib"
+  },
+  "include": ["src"]
+}

--- a/packages/ioc/tsconfig.es.json
+++ b/packages/ioc/tsconfig.es.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.es.json",
+  "compilerOptions": {
+    "outDir": "./dist/es6"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Motivation

Today, most standalone IOC libraries look pretty much alike:
- They may use symbols / strings as identifiers
- They mainly use decorators and classes (even if they provide factories, it is clearly not the "de-facto" solution)
- They don't provide correct shutdown lifecycle supports (they can't shutdown the services in your app in the correct order automatically)
- They don't provide custom scopes, or this feature is hard to understand / use.

## Solution

The IOC I wish to create should respond to these issues:
- Function based IOC: this encourages better splitting of concerns
- No magic strings / No symbols to define
- Easy custom scope management: In fact, the IOC in itself won't provide any scopes at all! You will have to create them yourself!
- Correct services shutdown support. Here some examples:
    - You can easily catch an error when mounting the application and gracefully shutdown the already mounted services.
    - You can easily gracefully shutdown the app when receiving a SIGINT signal

- Relatively low-level API to give an amount of flexibility and customability to the users
- Easy to integrate in existing projects
