### PR TITLE
chore: add publish via CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Node.js CI - Publish
+
+on:
+  push:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: yarn
+    - run: yarn build
+    - run: yarn test
+    - run: yarn pub:ci
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,8 +1,6 @@
-name: Node.js CI
+name: Node.js CI - PR
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "docs:build": "npm run build && npm run docs:generate && vuepress build docs",
     "postinstall": "husky install",
     "prepublishOnly": "npm run build && npm run test",
-    "pub": "lerna publish from-package --contents dist"
+    "pub": "lerna publish from-package --contents dist",
+    "pub:ci": "lerna publish from-package --contents dist --no-verify-access --yes"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -42,5 +42,8 @@
     "ts-jest": "^26.3.0",
     "ts-node": "^8.0.2",
     "typescript": "^4.1.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -42,5 +42,8 @@
     "ts-jest": "^26.3.0",
     "ts-node": "^8.0.2",
     "typescript": "^4.1.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
Automatically publish new package / new package version to NPM on pull request merging, **IF** the version in a package.json has been updated.

The package versions need to be manually updated for now. 