### PR TITLE
feat(tasks): support PromiseLike API

### DIFF
--- a/examples/std/simple.ts
+++ b/examples/std/simple.ts
@@ -1,20 +1,19 @@
-import { Arr, Err, pipe, Prom, Result, Task, TaskResult, throwError } from '@apoyo/std'
+import { Arr, Err, pipe, Prom, Result, Task, throwError } from '@apoyo/std'
 
 export const main = async () => {
-  const someTask: Task<number> = async () => {
+  const someTask: Task<number> = Task.thunk(async () => {
     await Prom.sleep(1000)
     return 42
-  }
+  })
 
   const tasks = [someTask, Task.reject(new Error('some error')), Task.of(1), Task.of(1)]
 
   const [ok, errors] = await pipe(
     tasks,
+    Arr.map(Task.mapError(Err.chain('Task failed'))),
     Arr.map(Task.tryCatch),
-    Arr.map(TaskResult.mapError(Err.chain('Task failed'))),
     Task.concurrent(4),
-    Task.map(Arr.separate),
-    Task.run
+    Task.map(Arr.separate)
   )
 
   console.log('Task results', { ok, errors })

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -33,8 +33,8 @@
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
   "dependencies": {
-    "@apoyo/decoders": "^0.0.3",
-    "@apoyo/std": "^0.0.5",
+    "@apoyo/decoders": "^0.0.4",
+    "@apoyo/std": "^0.0.7",
     "@types/papaparse": "^5.2.5",
     "papaparse": "^5.3.0"
   },

--- a/packages/csv/tests/CsvParser.spec.ts
+++ b/packages/csv/tests/CsvParser.spec.ts
@@ -108,15 +108,14 @@ describe('Csv.streamAsync', () => {
 
     let total = 0
     const result = await pipe(
-      async () => {
+      Task.thunk(async () => {
         for await (const rows of seq) {
           total += rows.length
           throw new Error('Abort')
         }
         return total
-      },
-      Task.tryCatch,
-      Task.run
+      }),
+      Task.tryCatch
     )
 
     const error = Result.isKo(result) ? result.ko : undefined
@@ -142,13 +141,12 @@ describe('Csv.streamAsync', () => {
     let total = 0
 
     const result = await pipe(
-      async () => {
+      Task.thunk(async () => {
         for await (const rows of seq) {
           total += rows.length
         }
-      },
-      Task.tryCatch,
-      Task.run
+      }),
+      Task.tryCatch
     )
     const error = Result.isKo(result) ? result.ko : undefined
 
@@ -164,13 +162,12 @@ describe('Csv.streamAsync', () => {
     let total = 0
 
     const result = await pipe(
-      async () => {
+      Task.thunk(async () => {
         for await (const rows of seq) {
           total += rows.length
         }
-      },
-      Task.tryCatch,
-      Task.run
+      }),
+      Task.tryCatch
     )
     const error = Result.isKo(result) ? result.ko : undefined
 

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/std",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Typescript utility library",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/packages/std/src/Task.ts
+++ b/packages/std/src/Task.ts
@@ -1,13 +1,14 @@
 import type { Dict } from './Dict'
 
-import * as D from './Dict'
 import * as A from './Array'
+import * as D from './Dict'
 import { fcurry2, identity, pipe } from './function'
 import { fromArray, shift } from './List'
 import * as P from './Promise'
 import { Result } from './Result'
 
-export type Task<A = any> = () => Promise<A>
+export type Task<T = any> = PromiseLike<T> & { _tag: 'Task' }
+
 export namespace Task {
   export type Strategy<A = any> = (tasks: Array<Task<A>>) => Task<Array<A>>
   export type Unwrap<A> = A extends Task<infer I> ? I : A
@@ -19,78 +20,99 @@ export namespace Task {
   >
 }
 
-export const of = <A>(value: A): Task<A> => () => P.of(value)
+export const thunk = <A>(fn: () => PromiseLike<A> | A): Task<A> => ({
+  _tag: 'Task',
+  then: (onResolve, onReject) => Promise.resolve().then(fn).then(onResolve, onReject)
+})
+
+export const isTask = <A>(value: unknown): value is Task<A> => (value as any)._tag === 'Task'
+
+export const of = <A>(value: A): Task<A> => thunk(() => P.of(value))
 export const resolve = of
-export const reject = (value: unknown): Task<never> => () => P.reject(value)
+export const reject = (value: unknown): Task<never> => thunk(() => P.reject(value))
 
-export const run = <A>(task: Task<A>): Promise<A> => task()
+export const run = <A>(task: Task<A>): Promise<A> => new Promise(task.then)
 
-export const sleep = (ms: number): Task<void> => () => P.sleep(ms)
-export const delay = (ms: number) => <A>(task: Task<A>): Task<A> => () => pipe(task(), P.delay(ms))
+export const map = <A, B>(fn: (value: A) => B) => (task: Task<A>): Task<B> => thunk(() => task.then(fn))
+export const tap = <A, B>(fn: (value: A) => PromiseLike<B> | B) => (task: Task<A>): Task<A> =>
+  pipe(
+    task,
+    chain((value) =>
+      pipe(
+        thunk(() => fn(value)),
+        map(() => value)
+      )
+    )
+  )
 
-export const map = <A, B>(fn: (value: A) => B) => (task: Task<A>): Task<B> => () => task().then(fn)
+export const mapError = <A>(fn: (err: unknown) => unknown) => (task: Task<A>): Task<A> =>
+  thunk(() => task.then(identity, (err) => P.reject(fn(err))))
 
-export const mapError = <A>(fn: (err: unknown) => unknown) => (task: Task<A>): Task<A> => () =>
-  task().catch((err) => P.reject(fn(err)))
+export const chain = <A, B>(fn: (value: A) => PromiseLike<B>) => (task: Task<A>): Task<B> =>
+  thunk(() => task.then((v) => fn(v)))
 
-export const chain = <A, B>(fn: (value: A) => Task<B>) => (task: Task<A>): Task<B> => () => task().then((v) => fn(v)())
+export const catchError = <A, B>(fn: (err: unknown) => Task<B>) => (task: Task<A>): Task<A | B> =>
+  thunk(() => task.then(identity, (err) => fn(err)))
 
-export const chainAsync = <A, B>(fn: (value: A) => Promise<B>) => (task: Task<A>): Task<B> => () => task().then(fn)
-
-export const catchError = <A, B>(fn: (err: unknown) => Task<B>) => (task: Task<A>): Task<A | B> => () =>
-  task().catch((err) => run(fn(err)))
+export const sleep = (ms: number): Task<void> => thunk(() => P.sleep(ms))
+export const delay = (ms: number) => <A>(task: Task<A>): Task<A> =>
+  pipe(
+    task,
+    tap(() => sleep(ms))
+  )
 
 export const join = <A>(task: Task<Task<A>>): Task<A> => pipe(task, chain(identity))
 
-export const all = <A>(tasks: Task<A>[]): Task<A[]> => async () => P.all(tasks.map(run))
+export const all = <A>(tasks: Task<A>[]): Task<A[]> => thunk(() => P.all(tasks))
 
-export const sequence = <A>(tasks: Task<A>[]): Task<A[]> => async () => {
-  const res: A[] = []
-  for (let i = 0; i < tasks.length; ++i) {
-    const task = tasks[i]
-    res.push(await task())
-  }
-  return res
-}
-
-export const concurrent = (concurrency: number) => <A>(tasks: Task<A>[]): Task<A[]> => async () => {
-  if (concurrency < 1) {
-    throw new Error(`Concurrency should be above 1 or above`)
-  }
-  if (concurrency === Number.POSITIVE_INFINITY || concurrency > tasks.length) {
-    concurrency = tasks.length
-  }
-
-  const results = Array(tasks.length)
-  const queue = fromArray(
-    tasks.map((task, index) => ({
-      index,
-      task
-    }))
-  )
-
-  const loop = async (): Promise<void> => {
-    let item = shift(queue)
-    while (item) {
-      const { index, task } = item
-      results[index] = await task()
-      item = shift(queue)
+export const sequence = <A>(tasks: Task<A>[]): Task<A[]> =>
+  thunk(async () => {
+    const res: A[] = []
+    for (let i = 0; i < tasks.length; ++i) {
+      const task = tasks[i]
+      res.push(await task)
     }
-  }
+    return res
+  })
 
-  const p: Promise<void>[] = []
-  for (let i = 0; i < concurrency; ++i) {
-    p.push(loop())
-  }
-  await P.all(p)
-  return results
-}
+export const concurrent = (concurrency: number) => <A>(tasks: Task<A>[]): Task<A[]> =>
+  thunk(async () => {
+    if (concurrency < 1) {
+      throw new Error(`Concurrency should be above 1 or above`)
+    }
+    if (concurrency === Number.POSITIVE_INFINITY || concurrency > tasks.length) {
+      concurrency = tasks.length
+    }
 
-export const tryCatch = <A, E = unknown>(fn: Task<A>): Task<Result<A, E>> => () => P.tryCatch(fn())
+    const results = Array(tasks.length)
+    const queue = fromArray(
+      tasks.map((task, index) => ({
+        index,
+        task
+      }))
+    )
 
-export const thunk = <A>(fn: () => Promise<A> | A): Task<A> => () => Promise.resolve().then(fn)
+    const loop = async (): Promise<void> => {
+      let item = shift(queue)
+      while (item) {
+        const { index, task } = item
+        results[index] = await task
+        item = shift(queue)
+      }
+    }
 
-export const timeout = <A>(ms: number, fn: Task<A>) => (task: Task<A>) => () => pipe(task(), P.timeout(ms, fn))
+    const p: Promise<void>[] = []
+    for (let i = 0; i < concurrency; ++i) {
+      p.push(loop())
+    }
+    await P.all(p)
+    return results
+  })
+
+export const tryCatch = <A, E = unknown>(task: Task<A>): Task<Result<A, E>> => thunk(() => P.tryCatch(task))
+
+export const timeout = <A>(ms: number, fn: () => PromiseLike<A> | A) => (task: Task<A>) =>
+  thunk(() => pipe(task, P.timeout(ms, fn)))
 
 export const struct = fcurry2(
   (obj: Dict<Task>, strategy: Task.Strategy): Task<Dict> => {
@@ -119,6 +141,12 @@ export const struct = fcurry2(
  * @see `Prom` - For eager asynchroneous actions.
  */
 export const Task = {
+  /**
+   * @description
+   * Check if variable is a task
+   */
+  isTask,
+
   /**
    * @description
    * Creates a resolving `Task`
@@ -214,7 +242,7 @@ export const Task = {
 
   /**
    * @description
-   * Chain another `Task` to execute when the `Task` resolves.
+   * Chain a `Task` or any other `PromiseLike` to execute when the `Task` resolves.
    *
    * @see `Task.map`
    * @see `Task.catchError`
@@ -234,29 +262,6 @@ export const Task = {
    * ```
    */
   chain,
-
-  /**
-   * @description
-   * Chain another promise to execute when the `Task` resolves.
-   *
-   * @see `Task.map`
-   * @see `Task.chain`
-   *
-   * @example
-   * ```ts
-   * const result = await pipe(
-   *   Task.of(1),
-   *   Task.chainAsync(async (a) => pipe(
-   *     Prom.of(a + 1),
-   *     Prom.delay(1000)
-   *   )),
-   *   Task.run
-   * )
-   *
-   * expect(result).toBe(2)
-   * ```
-   */
-  chainAsync,
 
   /**
    * @description

--- a/packages/std/src/TaskResult.ts
+++ b/packages/std/src/TaskResult.ts
@@ -1,5 +1,4 @@
 import { pipe } from './function'
-import { isIO } from './IO'
 import * as Result from './Result'
 import * as T from './Task'
 
@@ -34,7 +33,7 @@ export const catchError = <A, B, E>(fn: (err: any) => Result.Result<B, E> | Task
   )
 
 export const from = <A, E>(value: Result.Result<A, E> | TaskResult<A, E>): TaskResult<A, E> =>
-  isIO(value) ? value : T.of(value)
+  T.isTask(value) ? value : T.of(value)
 
 export const TaskResult = {
   ok,

--- a/packages/std/tests/Task.ts
+++ b/packages/std/tests/Task.ts
@@ -276,13 +276,21 @@ describe('Task.struct', () => {
 
 describe('Task.timeout', () => {
   it('should not timeout', async () => {
-    const result = await pipe(Task.of(10), Task.timeout(100, Task.of(0)), Task.run)
+    const result = await pipe(
+      Task.of(10),
+      Task.timeout(100, () => 0),
+      Task.run
+    )
     expect(result).toEqual(10)
   })
 
   it('should timeout', async () => {
     const original = pipe(Task.of(10), Task.delay(200))
-    const result = await pipe(original, Task.timeout(100, Task.of(0)), Task.run)
+    const result = await pipe(
+      original,
+      Task.timeout(100, () => Task.of(0)),
+      Task.run
+    )
     expect(result).toEqual(0)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,17 +2,10 @@
 # yarn lockfile v1
 
 
-"@apoyo/decoders@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@apoyo/decoders/-/decoders-0.0.3.tgz#c416822831cc51ed8c6a6aa9aaba4c4be7cf051b"
-  integrity sha512-BqH03cl+HFN1ekqRrcL0VEF4a1tFiGhAks8SzsseuclUPl6wPAt/ijCL3AMhh5McJWJCdRWDw1rb5hq+eocKyw==
-  dependencies:
-    "@apoyo/std" "^0.0.5"
-
-"@apoyo/std@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@apoyo/std/-/std-0.0.5.tgz#2a6463c3fea952b4337f6d0cd6ae9131475b06fd"
-  integrity sha512-2fjqyfUoZAJKTJv9aZ/GJeQMVEM4kUde7Gg6boMJyYyUoUIof0kHEDhbWji+FlT9hsNDwCpLMKtXHzBkWULTrA==
+"@apoyo/std@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@apoyo/std/-/std-0.0.6.tgz#a598316d1259e3bc4e1545a4d0b41de02d9bd760"
+  integrity sha512-natW+VQ2J7ew3330MIm5Y35HV/QfPSobAXrk1DUhsajWV4RGBzj8LsdtCHKArjIhuAKNLXhtcAV4tOLaBqJlyg==
 
 "@babel/code-frame@7.12.11":
   version "7.12.11"


### PR DESCRIPTION
**Features**:

- Tasks becomes a `PromiseLike` to better support Promises and `await`
- Promise utils now support `PromiseLike`

**BREAKING CHANGES**:
- Tasks are no longer functions: You should now only create tasks using an available utility function, like `Task.thunk`, `Task.of` or `Task.reject`