### PR TITLE
feat(decoders): improvements and autocasting

### DIFF
--- a/examples/csv/example.ts
+++ b/examples/csv/example.ts
@@ -18,8 +18,8 @@ export async function main() {
   const RowDecoder = ObjectDecoder.struct({
     id: TextDecoder.string,
     name: TextDecoder.string,
-    age: pipe(IntegerDecoder.fromString, IntegerDecoder.between(0, 120)),
-    isActive: BooleanDecoder.fromString,
+    age: pipe(IntegerDecoder.int, IntegerDecoder.between(0, 120)),
+    isActive: BooleanDecoder.boolean,
     email: TextDecoder.email
   })
 

--- a/examples/decoders/example.ts
+++ b/examples/decoders/example.ts
@@ -33,7 +33,7 @@ export const main = async () => {
   const UserDto = ObjectDecoder.struct({
     id: TextDecoder.string,
     email: TextDecoder.email,
-    status: EnumDecoder.from(UserStatus),
+    status: EnumDecoder.native(UserStatus),
     birthdate: pipe(DateDecoder.date, Decoder.parse(validateAge))
   })
 

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -33,7 +33,7 @@
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
   "dependencies": {
-    "@apoyo/decoders": "^0.0.6",
+    "@apoyo/decoders": "^0.0.7",
     "@apoyo/std": "^0.0.8",
     "@types/papaparse": "^5.2.5",
     "papaparse": "^5.3.0"

--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/decoders",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Validation utilities",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/packages/decoders/src/BooleanDecoder.ts
+++ b/packages/decoders/src/BooleanDecoder.ts
@@ -9,7 +9,7 @@ export type BooleanDecoder<I> = Decoder<I, boolean>
 const TEXT_TRUE = new Set(['true', 'yes', 'y', '1'])
 const TEXT_FALSE = new Set(['false', 'no', 'no', '0'])
 
-export const boolean: BooleanDecoder<unknown> = Decoder.fromGuard(
+export const strict: BooleanDecoder<unknown> = Decoder.fromGuard(
   (input: unknown): input is boolean => typeof input === 'boolean',
   `value is not a boolean`
 )
@@ -27,7 +27,7 @@ export const fromString = pipe(
 )
 
 export const fromNumber = pipe(
-  IntegerDecoder.int,
+  IntegerDecoder.strict,
   Decoder.parse((nb) =>
     nb === 1
       ? Result.ok(true)
@@ -35,6 +35,11 @@ export const fromNumber = pipe(
       ? Result.ok(false)
       : Result.ko(DecodeError.value(nb, `number is not a boolean`))
   )
+)
+
+export const boolean: BooleanDecoder<unknown> = pipe(
+  Decoder.union(strict, fromString, fromNumber),
+  Decoder.withMessage(`value is not a boolean`)
 )
 
 export const equals = <T extends boolean>(bool: T) =>
@@ -53,6 +58,16 @@ export const BooleanDecoder = {
   /**
    * @description
    * Check if the input is a boolean.
+   *
+   * This function is strict and does not autocast the input into a boolean.
+   */
+  strict,
+
+  /**
+   * @description
+   * Check if the input is a boolean.
+   *
+   * This function will autocast the input into a boolean if possible.
    */
   boolean,
 

--- a/packages/decoders/src/EnumDecoder.ts
+++ b/packages/decoders/src/EnumDecoder.ts
@@ -78,7 +78,7 @@ export const EnumDecoder = {
    *   ARCHIVED = "archived"
    * }
    *
-   * const decoder = EnumDecoder.native(Status)
+   * const decoder = EnumDecoder.from(Status)
    *
    * expect(pipe("active", Decoder.validate(decoder), Result.get)).toBe(Status.ACTIVE)
    * expect(pipe("xxx", Decoder.validate(decoder), Result.isKo)).toBe(true)

--- a/packages/decoders/src/EnumDecoder.ts
+++ b/packages/decoders/src/EnumDecoder.ts
@@ -1,17 +1,44 @@
 import { Enum } from '@apoyo/std'
 import { Decoder } from './Decoder'
 
-export type EnumDecoder<I> = Decoder<I, string | number>
+export type Literal = string | number | boolean | null
 
-const from = <E extends Enum<E>>(enumType: E) => {
+export type EnumDecoder<I, O> = Decoder<I, O> & {
+  values: Set<unknown>
+}
+
+const create = <I, O>(values: Set<unknown>, decoder: Decoder<I, O>): EnumDecoder<I, O> => ({
+  ...decoder,
+  values
+})
+
+const inSet = <T>(set: Set<T>) => (value: unknown): value is T => set.has(value as any)
+
+export const native = <E extends Enum<E>>(enumType: E): EnumDecoder<unknown, E[keyof E]> => {
   const values = Enum.values(enumType)
-  return Decoder.fromGuard(
-    (input: unknown): input is E[keyof E] => !!values.find((v) => v === input),
-    `input does not match any value in enumeration`,
-    {
+  const set = new Set(values)
+  return create(
+    set,
+    Decoder.fromGuard(inSet(set), `input does not match any value in enumeration`, {
       values
-    }
+    })
   )
+}
+
+export const literal = <A extends readonly [Literal, ...Literal[]]>(...values: [...A]): Decoder<unknown, A[number]> => {
+  const set = new Set(values)
+  return create(
+    set,
+    Decoder.fromGuard(inSet(set), `value is not equal to ${values.join(', or ')}`, {
+      values
+    })
+  )
+}
+
+export function isIn<T>(arr: T[] | Set<T>): Decoder<unknown, T>
+export function isIn(arr: any[] | Set<any>): any {
+  const set = arr instanceof Set ? arr : new Set<any>(arr)
+  return create(set, Decoder.fromGuard(inSet(set), `string is not included in the allowed list of values`))
 }
 
 export const EnumDecoder = {
@@ -27,11 +54,39 @@ export const EnumDecoder = {
    *   ARCHIVED = "archived"
    * }
    *
-   * const decoder = EnumDecoder.from(Status)
+   * const decoder = EnumDecoder.native(Status)
    *
    * expect(pipe("active", Decoder.validate(decoder), Result.get)).toBe(Status.ACTIVE)
    * expect(pipe("xxx", Decoder.validate(decoder), Result.isKo)).toBe(true)
    * ```
    */
-  from
+  native,
+
+  /**
+   * @description
+   * Checks if a value is in the given list of constants
+   *
+   * @example
+   * ```ts
+   * const decoder = EnumDecoder.literal("active", "inactive", "archived")
+   *
+   * expect(pipe("active", Decoder.validate(decoder), Result.get)).toBe("active")
+   * expect(pipe("xxx", Decoder.validate(decoder), Result.isKo)).toBe(true)
+   * ```
+   */
+  literal,
+
+  /**
+   * @description
+   * Checks if a value is in the given list
+   *
+   * @example
+   * ```ts
+   * const decoder = EnumDecoder.isIn(["active", "inactive", "archived"])
+   *
+   * expect(pipe("active", Decoder.validate(decoder), Result.get)).toBe("active")
+   * expect(pipe("xxx", Decoder.validate(decoder), Result.isKo)).toBe(true)
+   * ```
+   */
+  isIn
 }

--- a/packages/decoders/src/EnumDecoder.ts
+++ b/packages/decoders/src/EnumDecoder.ts
@@ -25,6 +25,8 @@ export const native = <E extends Enum<E>>(enumType: E): EnumDecoder<unknown, E[k
   )
 }
 
+export const from = native
+
 export const literal = <A extends readonly [Literal, ...Literal[]]>(...values: [...A]): Decoder<unknown, A[number]> => {
   const set = new Set(values)
   return create(
@@ -61,6 +63,28 @@ export const EnumDecoder = {
    * ```
    */
   native,
+
+  /**
+   * @deprecated Use `EnumDecoder.native` instead.
+   *
+   * @description
+   * Checks if a value is included in the given enum
+   *
+   * @example
+   * ```ts
+   * enum Status {
+   *   ACTIVE = "active",
+   *   INACTIVE = "inactive",
+   *   ARCHIVED = "archived"
+   * }
+   *
+   * const decoder = EnumDecoder.native(Status)
+   *
+   * expect(pipe("active", Decoder.validate(decoder), Result.get)).toBe(Status.ACTIVE)
+   * expect(pipe("xxx", Decoder.validate(decoder), Result.isKo)).toBe(true)
+   * ```
+   */
+  from,
 
   /**
    * @description

--- a/packages/decoders/src/IntegerDecoder.ts
+++ b/packages/decoders/src/IntegerDecoder.ts
@@ -5,14 +5,19 @@ import { Int } from './types'
 
 export type IntegerDecoder<I> = Decoder<I, Int>
 
-export const int: IntegerDecoder<unknown> = pipe(
-  NumberDecoder.number,
+export const strict: IntegerDecoder<unknown> = pipe(
+  NumberDecoder.strict,
   Decoder.filter((nb): nb is Int => nb % 1 === 0, `number is not a integer`)
 )
 
 export const fromString = pipe(
   NumberDecoder.fromString,
-  Decoder.chain(() => int)
+  Decoder.chain(() => strict)
+)
+
+export const int: IntegerDecoder<unknown> = pipe(
+  Decoder.union(strict, fromString),
+  Decoder.withMessage(`value is not a integer`)
 )
 
 export const min = NumberDecoder.min as (minimum: number) => <I>(decoder: IntegerDecoder<I>) => IntegerDecoder<I>
@@ -38,6 +43,17 @@ export const IntegerDecoder = {
    * @description
    * Check if the input is an integer.
    * If the integer is NaN or contains decimals, the number will fail validation.
+   *
+   * This function is strict and does not autocast the input into a number.
+   */
+  strict,
+
+  /**
+   * @description
+   * Check if the input is an integer.
+   * If the integer is NaN or contains decimals, the number will fail validation.
+   *
+   * This function will autocast the input into a number if possible.
    */
   int,
 

--- a/packages/decoders/src/NumberDecoder.ts
+++ b/packages/decoders/src/NumberDecoder.ts
@@ -4,7 +4,7 @@ import { TextDecoder } from './TextDecoder'
 
 export type NumberDecoder<I> = Decoder<I, number>
 
-export const number: NumberDecoder<unknown> = Decoder.fromGuard(
+export const strict: NumberDecoder<unknown> = Decoder.fromGuard(
   (input: unknown): input is number => typeof input === 'number' && !Number.isNaN(input),
   `value is not a number`
 )
@@ -12,7 +12,12 @@ export const number: NumberDecoder<unknown> = Decoder.fromGuard(
 export const fromString = pipe(
   TextDecoder.string,
   Decoder.map(parseFloat),
-  Decoder.chain(() => number)
+  Decoder.chain(() => strict)
+)
+
+export const number: NumberDecoder<unknown> = pipe(
+  Decoder.union(strict, fromString),
+  Decoder.withMessage(`value is not a number`)
 )
 
 export const min = (minimum: number) =>
@@ -39,6 +44,17 @@ export const NumberDecoder = {
    * @description
    * Check if the input is a number.
    * If the number is NaN, the number will fail validation.
+   *
+   * This function is strict and does not autocast the input into a number.
+   */
+  strict,
+
+  /**
+   * @description
+   * Check if the input is a number.
+   * If the number is NaN, the number will fail validation.
+   *
+   * This function will autocast the input into a number if possible.
    */
   number,
 

--- a/packages/decoders/src/ObjectDecoder.ts
+++ b/packages/decoders/src/ObjectDecoder.ts
@@ -330,7 +330,7 @@ export const ObjectDecoder = {
    * ```ts
    * const Response = pipe(
    *   ObjectDecoder.struct({
-   *     status: TextDecoder.oneOf(['OK', 'KO']),
+   *     status: EnumDecoder.literal('OK', 'KO'),
    *     message: TextDecoder.string,
    *   }),
    *   ObjectDecoder.additionalProperties

--- a/packages/decoders/src/TextDecoder.ts
+++ b/packages/decoders/src/TextDecoder.ts
@@ -1,5 +1,4 @@
 import { flow, pipe, Str } from '@apoyo/std'
-import { EnumDecoder } from './EnumDecoder'
 import { Decoder } from './Decoder'
 import { Email, UUID } from './types'
 
@@ -63,8 +62,23 @@ export const uuid = pipe(
   Decoder.filter((str): str is UUID => REGEXP_UUID.test(str), `string is not an uuid`)
 )
 
-export const equals = EnumDecoder.literal
-export const oneOf = EnumDecoder.isIn
+export const equals = <T extends string>(value: T) =>
+  pipe(
+    string,
+    Decoder.filter((str): str is T => str === value, `string is not equal to value ${JSON.stringify(value)}`)
+  )
+
+export function oneOf<T extends string>(arr: T[]): Decoder<unknown, T>
+export function oneOf<T extends string>(arr: Set<T>): Decoder<unknown, T>
+export function oneOf(arr: string[] | Set<string>): any {
+  const set = new Set(arr)
+  return pipe(
+    string,
+    Decoder.filter((str: string) => set.has(str), `string is not included in the given values`, {
+      values: arr
+    })
+  )
+}
 
 /**
  * @namespace TextDecoder

--- a/packages/decoders/src/TextDecoder.ts
+++ b/packages/decoders/src/TextDecoder.ts
@@ -1,4 +1,5 @@
 import { flow, pipe, Str } from '@apoyo/std'
+import { EnumDecoder } from './EnumDecoder'
 import { Decoder } from './Decoder'
 import { Email, UUID } from './types'
 
@@ -62,23 +63,8 @@ export const uuid = pipe(
   Decoder.filter((str): str is UUID => REGEXP_UUID.test(str), `string is not an uuid`)
 )
 
-export const equals = <T extends string>(value: T) =>
-  pipe(
-    string,
-    Decoder.filter((str): str is T => str === value, `string is not equal to value ${JSON.stringify(value)}`)
-  )
-
-export function oneOf<T extends string>(arr: T[]): Decoder<unknown, T>
-export function oneOf<T extends string>(arr: Set<T>): Decoder<unknown, T>
-export function oneOf(arr: string[] | Set<string>): any {
-  const set = new Set(arr)
-  return pipe(
-    string,
-    Decoder.filter((str: string) => set.has(str), `string is not included in the given values`, {
-      values: arr
-    })
-  )
-}
+export const equals = EnumDecoder.literal
+export const oneOf = EnumDecoder.isIn
 
 /**
  * @namespace TextDecoder
@@ -235,6 +221,8 @@ export const TextDecoder = {
   optional,
 
   /**
+   * @deprecated Use `EnumDecoder.isIn` instead.
+   *
    * @description
    * Check if the string is included in the given values
    *
@@ -249,6 +237,8 @@ export const TextDecoder = {
   oneOf,
 
   /**
+   * @deprecated Use `EnumDecoder.literal` instead.
+   *
    * @description
    * Check if the string is included in the given values
    *

--- a/packages/decoders/tests/BooleanDecoder.spec.ts
+++ b/packages/decoders/tests/BooleanDecoder.spec.ts
@@ -1,10 +1,10 @@
 import { pipe, Result } from '@apoyo/std'
 import { BooleanDecoder, Decoder } from '../src'
 
-describe('BooleanDecoder.boolean', () => {
+describe('BooleanDecoder.strict', () => {
   it('should succeed', () => {
-    expect(pipe(true, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(true)
-    expect(pipe(false, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(false)
+    expect(pipe(true, Decoder.validate(BooleanDecoder.strict), Result.get)).toBe(true)
+    expect(pipe(false, Decoder.validate(BooleanDecoder.strict), Result.get)).toBe(false)
   })
 
   it('should fail', () => {
@@ -56,5 +56,21 @@ describe('BooleanDecoder.equals', () => {
 
     expect(pipe(1, Decoder.validate(BooleanDecoder.equals(true)), Result.isKo)).toBe(true)
     expect(pipe(false, Decoder.validate(BooleanDecoder.equals(true)), Result.isKo)).toBe(true)
+  })
+})
+
+describe('BooleanDecoder.boolean', () => {
+  it('should succeed', () => {
+    expect(pipe(true, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(true)
+    expect(pipe(false, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(false)
+    expect(pipe(1, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(true)
+    expect(pipe(0, Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(false)
+    expect(pipe('true', Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(true)
+    expect(pipe('false', Decoder.validate(BooleanDecoder.boolean), Result.get)).toBe(false)
+  })
+
+  it('should fail', () => {
+    expect(pipe('42', Decoder.validate(BooleanDecoder.boolean), Result.isKo)).toBe(true)
+    expect(pipe(42, Decoder.validate(BooleanDecoder.boolean), Result.isKo)).toBe(true)
   })
 })

--- a/packages/decoders/tests/BooleanDecoder.spec.ts
+++ b/packages/decoders/tests/BooleanDecoder.spec.ts
@@ -8,8 +8,8 @@ describe('BooleanDecoder.strict', () => {
   })
 
   it('should fail', () => {
-    expect(pipe(0, Decoder.validate(BooleanDecoder.boolean), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(BooleanDecoder.boolean), Result.isKo)).toBe(true)
+    expect(pipe(0, Decoder.validate(BooleanDecoder.strict), Result.isKo)).toBe(true)
+    expect(pipe('true', Decoder.validate(BooleanDecoder.strict), Result.isKo)).toBe(true)
   })
 })
 
@@ -46,15 +46,14 @@ describe('BooleanDecoder.fromNumber', () => {
 
 describe('BooleanDecoder.equals', () => {
   it('should succeed', () => {
-    expect(pipe(false, Decoder.validate(BooleanDecoder.equals(false)), Result.get)).toBe(false)
-    expect(pipe(true, Decoder.validate(BooleanDecoder.equals(true)), Result.get)).toBe(true)
+    expect(pipe(false, Decoder.validate(BooleanDecoder.equals(false)), Result.isOk)).toBe(true)
+    expect(pipe(true, Decoder.validate(BooleanDecoder.equals(true)), Result.isOk)).toBe(true)
+    expect(pipe(0, Decoder.validate(BooleanDecoder.equals(false)), Result.isOk)).toBe(true)
+    expect(pipe(1, Decoder.validate(BooleanDecoder.equals(true)), Result.isOk)).toBe(true)
   })
 
   it('should fail', () => {
-    expect(pipe(0, Decoder.validate(BooleanDecoder.equals(false)), Result.isKo)).toBe(true)
     expect(pipe(true, Decoder.validate(BooleanDecoder.equals(false)), Result.isKo)).toBe(true)
-
-    expect(pipe(1, Decoder.validate(BooleanDecoder.equals(true)), Result.isKo)).toBe(true)
     expect(pipe(false, Decoder.validate(BooleanDecoder.equals(true)), Result.isKo)).toBe(true)
   })
 })

--- a/packages/decoders/tests/Decoder.spec.ts
+++ b/packages/decoders/tests/Decoder.spec.ts
@@ -161,3 +161,21 @@ describe('Decode.union', () => {
     expect(res).toBe(true)
   })
 })
+
+describe('Decode.withMessage', () => {
+  const message = 'The given value is not a number'
+  const decoder = pipe(
+    Decoder.union(NumberDecoder.number, NumberDecoder.fromString),
+    Decoder.withMessage(message, {
+      code: 'invalid_number'
+    })
+  )
+
+  it('should return expected message', () => {
+    const input = '  Hello  '
+    const expectedError = DecodeError.value(input, message, {
+      code: 'invalid_number'
+    })
+    expect(pipe(input, Decoder.validate(decoder))).toEqual(Result.ko(expectedError))
+  })
+})

--- a/packages/decoders/tests/EnumDecoder.spec.ts
+++ b/packages/decoders/tests/EnumDecoder.spec.ts
@@ -7,8 +7,8 @@ enum Status {
   ARCHIVED = 'archived'
 }
 
-describe('EnumDecoder.from', () => {
-  const decoder = EnumDecoder.from(Status)
+describe('EnumDecoder.native', () => {
+  const decoder = EnumDecoder.native(Status)
 
   it('should succeed', () => {
     expect(pipe(Status.ACTIVE, Decoder.validate(decoder), Result.get)).toBe(Status.ACTIVE)
@@ -17,5 +17,41 @@ describe('EnumDecoder.from', () => {
 
   it('should fail', () => {
     expect(pipe('xxx', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+})
+
+describe('EnumDecoder.literal', () => {
+  const decoder = pipe(EnumDecoder.literal('ongoing'))
+  const multiple = pipe(EnumDecoder.literal('todo', 'ongoing', 'done'))
+
+  it('should succeed', () => {
+    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
+  })
+
+  it('should fail', () => {
+    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+
+  it('should succeed with multiple', () => {
+    expect(pipe('todo', Decoder.validate(multiple), Result.isOk)).toBe(true)
+    expect(pipe('ongoing', Decoder.validate(multiple), Result.isOk)).toBe(true)
+    expect(pipe('done', Decoder.validate(multiple), Result.isOk)).toBe(true)
+  })
+
+  it('should fail with multiple', () => {
+    expect(pipe('anything else', Decoder.validate(multiple), Result.isKo)).toBe(true)
+  })
+})
+
+describe('EnumDecoder.isIn', () => {
+  const decoder = pipe(EnumDecoder.isIn(['todo', 'ongoing', 'done']))
+  it('should succeed', () => {
+    expect(pipe('todo', Decoder.validate(decoder), Result.isOk)).toBe(true)
+    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
+    expect(pipe('done', Decoder.validate(decoder), Result.isOk)).toBe(true)
+  })
+
+  it('should fail', () => {
+    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })

--- a/packages/decoders/tests/IntegerDecoder.spec.ts
+++ b/packages/decoders/tests/IntegerDecoder.spec.ts
@@ -38,7 +38,6 @@ describe('IntegerDecoder.min', () => {
   it('should fail', () => {
     expect(pipe(-42.12, Decoder.validate(decoder), Result.isKo)).toBe(true)
     expect(pipe(-42, Decoder.validate(decoder), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
 
@@ -52,7 +51,6 @@ describe('IntegerDecoder.max', () => {
   it('should fail', () => {
     expect(pipe(-42.12, Decoder.validate(decoder), Result.isKo)).toBe(true)
     expect(pipe(42, Decoder.validate(decoder), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
 

--- a/packages/decoders/tests/IntegerDecoder.spec.ts
+++ b/packages/decoders/tests/IntegerDecoder.spec.ts
@@ -1,17 +1,17 @@
 import { pipe, Result } from '@apoyo/std'
 import { Decoder, IntegerDecoder } from '../src'
 
-describe('IntegerDecoder.int', () => {
+describe('IntegerDecoder.strict', () => {
   it('should succeed', () => {
-    expect(pipe(42, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
-    expect(pipe(-42, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
-    expect(pipe(0, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+    expect(pipe(42, Decoder.validate(IntegerDecoder.strict), Result.isOk)).toBe(true)
+    expect(pipe(-42, Decoder.validate(IntegerDecoder.strict), Result.isOk)).toBe(true)
+    expect(pipe(0, Decoder.validate(IntegerDecoder.strict), Result.isOk)).toBe(true)
   })
 
   it('should fail', () => {
-    expect(pipe(NaN, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
-    expect(pipe(42.24, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
-    expect(pipe(-42.12, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
+    expect(pipe(NaN, Decoder.validate(IntegerDecoder.strict), Result.isKo)).toBe(true)
+    expect(pipe(42.24, Decoder.validate(IntegerDecoder.strict), Result.isKo)).toBe(true)
+    expect(pipe(-42.12, Decoder.validate(IntegerDecoder.strict), Result.isKo)).toBe(true)
   })
 })
 
@@ -88,5 +88,22 @@ describe('IntegerDecoder.fromString', () => {
 
     // Not an integer
     expect(pipe('7.2', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+})
+
+describe('IntegerDecoder.int', () => {
+  it('should succeed', () => {
+    expect(pipe(42, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+    expect(pipe(-42, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+    expect(pipe(0, Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+    expect(pipe('-42', Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+    expect(pipe('42', Decoder.validate(IntegerDecoder.int), Result.isOk)).toBe(true)
+  })
+
+  it('should fail', () => {
+    expect(pipe(NaN, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
+    expect(pipe(42.24, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
+    expect(pipe(-42.12, Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
+    expect(pipe('42.12', Decoder.validate(IntegerDecoder.int), Result.isKo)).toBe(true)
   })
 })

--- a/packages/decoders/tests/NumberDecoder.spec.ts
+++ b/packages/decoders/tests/NumberDecoder.spec.ts
@@ -24,7 +24,6 @@ describe('NumberDecoder.min', () => {
 
   it('should fail', () => {
     expect(pipe(-42, Decoder.validate(decoder), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
 
@@ -38,7 +37,6 @@ describe('NumberDecoder.max', () => {
 
   it('should fail', () => {
     expect(pipe(42, Decoder.validate(decoder), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
 

--- a/packages/decoders/tests/NumberDecoder.spec.ts
+++ b/packages/decoders/tests/NumberDecoder.spec.ts
@@ -1,16 +1,16 @@
 import { pipe, Result } from '@apoyo/std'
 import { Decoder, NumberDecoder } from '../src'
 
-describe('NumberDecoder.number', () => {
+describe('NumberDecoder.strict', () => {
   it('should succeed', () => {
-    expect(pipe(42, Decoder.validate(NumberDecoder.number), Result.get)).toBe(42)
-    expect(pipe(-42, Decoder.validate(NumberDecoder.number), Result.get)).toBe(-42)
-    expect(pipe(42.12, Decoder.validate(NumberDecoder.number), Result.get)).toBe(42.12)
+    expect(pipe(42, Decoder.validate(NumberDecoder.strict), Result.get)).toBe(42)
+    expect(pipe(-42, Decoder.validate(NumberDecoder.strict), Result.get)).toBe(-42)
+    expect(pipe(42.12, Decoder.validate(NumberDecoder.strict), Result.get)).toBe(42.12)
   })
 
   it('should fail', () => {
-    expect(pipe(NaN, Decoder.validate(NumberDecoder.number), Result.isKo)).toBe(true)
-    expect(pipe('42', Decoder.validate(NumberDecoder.number), Result.isKo)).toBe(true)
+    expect(pipe(NaN, Decoder.validate(NumberDecoder.strict), Result.isKo)).toBe(true)
+    expect(pipe('42', Decoder.validate(NumberDecoder.strict), Result.isKo)).toBe(true)
   })
 })
 
@@ -71,5 +71,20 @@ describe('NumberDecoder.fromString', () => {
     // Not in range
     expect(pipe('-1', Decoder.validate(decoder), Result.isKo)).toBe(true)
     expect(pipe('9', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+})
+
+describe('NumberDecoder.number', () => {
+  it('should succeed', () => {
+    expect(pipe(42, Decoder.validate(NumberDecoder.number), Result.get)).toBe(42)
+    expect(pipe(-42, Decoder.validate(NumberDecoder.number), Result.get)).toBe(-42)
+    expect(pipe(42.12, Decoder.validate(NumberDecoder.number), Result.get)).toBe(42.12)
+    expect(pipe('42', Decoder.validate(NumberDecoder.number), Result.get)).toBe(42)
+    expect(pipe('42.12', Decoder.validate(NumberDecoder.number), Result.get)).toBe(42.12)
+  })
+
+  it('should fail', () => {
+    expect(pipe(NaN, Decoder.validate(NumberDecoder.number), Result.isKo)).toBe(true)
+    expect(pipe('Hello', Decoder.validate(NumberDecoder.number), Result.isKo)).toBe(true)
   })
 })

--- a/packages/decoders/tests/TextDecoder.spec.ts
+++ b/packages/decoders/tests/TextDecoder.spec.ts
@@ -136,27 +136,3 @@ describe('TextDecoder.optional', () => {
     expect(pipe(null, Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
-
-describe('TextDecoder.equals', () => {
-  const decoder = pipe(TextDecoder.equals('ongoing'))
-  it('should succeed', () => {
-    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
-  })
-
-  it('should fail', () => {
-    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
-  })
-})
-
-describe('TextDecoder.oneOf', () => {
-  const decoder = pipe(TextDecoder.oneOf(['todo', 'ongoing', 'done']))
-  it('should succeed', () => {
-    expect(pipe('todo', Decoder.validate(decoder), Result.isOk)).toBe(true)
-    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
-    expect(pipe('done', Decoder.validate(decoder), Result.isOk)).toBe(true)
-  })
-
-  it('should fail', () => {
-    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
-  })
-})

--- a/packages/decoders/tests/TextDecoder.spec.ts
+++ b/packages/decoders/tests/TextDecoder.spec.ts
@@ -136,3 +136,27 @@ describe('TextDecoder.optional', () => {
     expect(pipe(null, Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
+
+describe('TextDecoder.equals', () => {
+  const decoder = pipe(TextDecoder.equals('ongoing'))
+  it('should succeed', () => {
+    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
+  })
+
+  it('should fail', () => {
+    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+})
+
+describe('TextDecoder.oneOf', () => {
+  const decoder = pipe(TextDecoder.oneOf(['todo', 'ongoing', 'done']))
+  it('should succeed', () => {
+    expect(pipe('todo', Decoder.validate(decoder), Result.isOk)).toBe(true)
+    expect(pipe('ongoing', Decoder.validate(decoder), Result.isOk)).toBe(true)
+    expect(pipe('done', Decoder.validate(decoder), Result.isOk)).toBe(true)
+  })
+
+  it('should fail', () => {
+    expect(pipe('anything else', Decoder.validate(decoder), Result.isKo)).toBe(true)
+  })
+})


### PR DESCRIPTION
Features:

- Decoder.withMessage to replace the validation error by a new one

- NumberDecoder.number now autocasts input into a number
- NumberDecoder.strict to strictly validate a number

- IntegerDecoder.number now autocasts input into a integer
- IntegerDecoder.strict to strictly validate a integer

- BooleanDecoder.number now autocasts input into a boolean
- BooleanDecoder.strict to strictly validate a boolean

- EnumDecoder

Deprecations:

- EnumDecoder.from -> EnumDecoder.native
- TextDecoder.equals -> EnumDecoder.literal
- TextDecoder.oneOf -> EnumDecoder.isIn

Issues:

- Closes https://github.com/neoxia/apoyo/issues/33

NO BREAKING CHANGES!