### PR TITLE
feat(deps): install packages peer dependencies for better versionning

### DIFF
--- a/docs/guide/decoders/getting-started.md
+++ b/docs/guide/decoders/getting-started.md
@@ -10,6 +10,10 @@ However, we would appreciate any feedback you have on how to improve this librar
 
 ## Installation
 
+Install peer dependencies:
+`npm install @apoyo/std`
+
+Install package:
 `npm install @apoyo/decoders`
 
 ## Introduction

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -33,12 +33,12 @@
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
   "dependencies": {
-    "@apoyo/decoders": "^0.0.7",
-    "@apoyo/std": "^0.0.8",
     "@types/papaparse": "^5.2.5",
     "papaparse": "^5.3.0"
   },
   "devDependencies": {
+    "@apoyo/decoders": "^0.0.8",
+    "@apoyo/std": "^0.0.8",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",
     "jest": "^26.4.2",
@@ -46,5 +46,9 @@
     "ts-jest": "^26.3.0",
     "ts-node": "^8.0.2",
     "typescript": "^4.1.2"
+  },
+  "peerDependencies": {
+    "@apoyo/decoders": "^0.0.8",
+    "@apoyo/std": "^0.0.8"
   }
 }

--- a/packages/decoders/README.md
+++ b/packages/decoders/README.md
@@ -14,85 +14,16 @@ However, we would appreciate any feedback you have on how to improve this librar
 
 ## Installation
 
+Install peer dependencies:
+`npm install @apoyo/std`
+
+Install package:
 `npm install @apoyo/decoders`
 
-## Usage
+## Documentation
 
-```ts
-import { ObjectDecoder, DateDecoder, IntegerDecoder, TextDecoder, Decoder, BooleanDecoder } from '@apoyo/decoders'
-import { pipe, Result } from '@apoyo/std'
+Please visit the [documentation](https://nx-apoyo.netlify.app/guide/decoders/getting-started.html) for more information, examples and more.
 
-const validateAge = (dob: string) => {
-  const now = new Date()
-  const date = new Date(dob)
+## License
 
-  if (date.getFullYear() < now.getFullYear() - 100) {
-    return Result.ko(DecodeError.value(dob, 'Date of birth is more than 100 years ago'))
-  }
-  if (date.getFullYear() > now.getFullYear() - 18) {
-    return Result.ko(DecodeError.value(dob, 'Date of birth is less than 18 years ago'))
-  }
-  return Result.ok(dob)
-}
-
-const TodoDto = ObjectDecoder.struct({
-  id: TextDecoder.string,
-  email: TextDecoder.email,
-  name: pipe(TextDecoder.varchar(1, 100), Decoder.nullable),
-  dob: pipe(DateDecoder.date, Decoder.parse(validateAge), Decoder.nullable),
-  age: IntegerDecoder.range(0, 120),
-  title: TextDecoder.varchar(1, 100),
-  done: pipe(BooleanDecoder.boolean),
-  description: pipe(TextDecoder.varchar(0, 2000), TextDecoder.nullable),
-  createdAt: DateDecoder.datetime,
-  updatedAt: DateDecoder.datetime
-})
-
-const TodoPostDto = pipe(TodoDto, ObjectDecoder.omit(['id', 'createdAt', 'updatedAt']))
-const TodoPutDto = pipe(TodoDto, ObjectDecoder.partial, ObjectDecoder.omit(['id', 'createdAt', 'updatedAt']))
-
-interface TodoDto extends Decoder.TypeOf<typeof TodoDto> {}
-interface TodoPostDto extends Decoder.TypeOf<typeof TodoPostDto> {}
-interface TodoPutDto extends Decoder.TypeOf<typeof TodoPutDto> {}
-
-```
-
-## Example
-
-Let's say your are implementing a HTTP REST API endpoint to create a todo list item.
-
-You would like to validate the POST payload before creating the todo item in database.
-
-Or return an unprocessable entity HTTP error if payload is invalid.
-
-Here's how you can do with Apoyo's decoders:
-
-```typescript
-import { DecodeError } from '@apoyo/decoders'
-import { pipe, Result } from '@apoyo/std'
-import { TodoModel } from './models'
-
-export const handler = async (event: HttpEvent) => {
-  // Result is an union between OK and KO result
-  const result = pipe(
-    event.body, 
-    Decoder.validate(TodoPostDto)
-  )
-
-  // Use type guard isKo to properly cast result
-  if (Result.isKo(result)) {
-    // If error result return "Unprocessable entity" and properly format errors with flatten 
-    return {
-      status: 422,
-      body: DecodeError.flatten(result.ko)
-    }
-  }
-  // If payload is valid, save item (result.ok should have the correct type) 
-  const saved = await TodoModel.save(result.ok)
-  // And return status "Created"
-  return {
-    status: 201,
-    body: saved,
-  }
-}
-```
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/decoders",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Validation utilities",
   "main": "lib/index.js",
   "module": "es6/index.js",
@@ -31,10 +31,8 @@
     "prebuild": "npm run clean",
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
-  "dependencies": {
-    "@apoyo/std": "^0.0.8"
-  },
   "devDependencies": {
+    "@apoyo/std": "^0.0.8",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",
     "jest": "^26.4.2",
@@ -42,6 +40,9 @@
     "ts-jest": "^26.3.0",
     "ts-node": "^8.0.2",
     "typescript": "^4.1.2"
+  },
+  "peerDependencies": {
+    "@apoyo/std": "^0.0.8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Issue

Today, @apoyo/std is a direct dependency of @apoyo/decoders and co.
However, this means that if you want to upgrade `@apoyo/std` independently, a second version of this package will be installed.

Example: By installing `@apoyo/decoders 0.0.4` (which depends on `@apoyo/std 0.0.6`) and `@apoyo/std 0.0.8`, both versions of the std will be installed.

When writing the following code:
```ts
export const validateEnv = <T>(env: Dict, decoder: Decoder<unknown, T>) => pipe(
  env,
  Decoder.validate(decoder),
  Result.mapError(DecodeError.draw),
  Result.mapError(Err.of),
  Result.get
)
```

You may then get this type of error:
```
Argument of type '<A_7>(result: Result<A_7, DecodeError>) => Result<A_7, string>' is not assignable to parameter of type '(b: DecoderResult<T>) => Result<T, string>'.
  Types of parameters 'result' and 'b' are incompatible.
    Type 'DecoderResult<T>' is not assignable to type 'Result<T, DecodeError>'.
      Type 'Ko<DecodeError>' is not assignable to type 'Result<T, DecodeError>'.
        Type '...'.
          Types of property '_tag' are incompatible.
            Type 'Tags.Ko' is not assignable to type 'Tags.Ko'. Two different types with this name exist, but they are unrelated.ts(2345)
(property) draw: (e: DecodeError) => string
```

## Solution

The solution to this issue is to make @apoyo/std into a peerDependency.