### PR TITLE
feat(std): Option functions types improvements + Str missing utilities

### DIFF
--- a/examples/decoders/example.ts
+++ b/examples/decoders/example.ts
@@ -1,4 +1,4 @@
-import { pipe, Result } from '@apoyo/std'
+import { Option, pipe, Result } from '@apoyo/std'
 import {
   ArrayDecoder,
   BooleanDecoder,
@@ -47,13 +47,14 @@ export const main = async () => {
       ArrayDecoder.array(TagDto),
       ArrayDecoder.between(0, 5),
       Decoder.optional,
-      Decoder.map((input) => (input === undefined ? [] : input))
+      Decoder.map(Option.get(() => []))
     ),
     description: pipe(
       TextDecoder.varchar(0, 2000),
       Decoder.nullable,
       Decoder.optional,
-      Decoder.map((input) => (input === '' || input === undefined ? null : input))
+      Decoder.map(Option.fromString),
+      Decoder.map(Option.get(null))
     ),
     createdAt: DateDecoder.datetime,
     updatedAt: DateDecoder.datetime

--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@apoyo/decoders": "^0.0.8",
-    "@apoyo/std": "^0.0.8",
+    "@apoyo/std": "^0.0.9",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",
     "jest": "^26.4.2",

--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -32,7 +32,7 @@
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
   "devDependencies": {
-    "@apoyo/std": "^0.0.8",
+    "@apoyo/std": "^0.0.9",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",
     "jest": "^26.4.2",

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/std",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Typescript utility library",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/packages/std/src/Array.ts
+++ b/packages/std/src/Array.ts
@@ -97,7 +97,7 @@ export const slice = (start?: number, end?: number) => <A>(arr: A[]) => arr.slic
 export const take = (nb: number) => slice(0, nb)
 export const skip = (nb: number) => slice(nb)
 
-export const sort = <A>(ord: Ord<A>) => (arr: A[]) =>
+export const sort = <A>(ord: Ord<A>) => <C extends A>(arr: C[]): C[] =>
   arr
     .map(of)
     .sort(pipe(ord, contramap(NEA.head)))

--- a/packages/std/src/NonEmptyArray.ts
+++ b/packages/std/src/NonEmptyArray.ts
@@ -1,4 +1,4 @@
-import { isNonEmpty } from './Array'
+import * as Arr from './Array'
 import { pipe } from './function'
 import { Option } from './Option'
 import * as Ord from './Ord'
@@ -10,7 +10,7 @@ export const of = <A>(value: A): NonEmptyArray<A> => [value]
 export function fromArray<A>(arr: NonEmptyArray<A>): NonEmptyArray<A>
 export function fromArray<A>(arr: A[]): Option<NonEmptyArray<A>>
 export function fromArray<A>(arr: A[]) {
-  return isNonEmpty(arr) ? arr : undefined
+  return Arr.isNonEmpty(arr) ? arr : undefined
 }
 
 export const head = <A>(arr: NonEmptyArray<A>): A => arr[0]
@@ -32,6 +32,10 @@ export const map = <A, B>(fn: (value: A) => B) => (arr: NonEmptyArray<A>): NonEm
 
 export const min = <A>(ord: Ord.Ord<A>) => (arr: NonEmptyArray<A>): A => arr.reduce(Ord.min(ord), arr[0])
 export const max = <A>(ord: Ord.Ord<A>) => min(Ord.inverse(ord))
+
+export const sort = (Arr.sort as unknown) as {
+  <A>(ord: Ord.Ord<A>): <C extends A>(arr: NonEmptyArray<C>) => NonEmptyArray<C>
+}
 
 /**
  * @namespace NonEmptyArray
@@ -186,5 +190,25 @@ export const NonEmptyArray = {
    * expect(greatestNb).toBe(7)
    * ```
    */
-  max
+  max,
+
+  /**
+   * @description
+   * Sort array by the given `Ord` function.
+   *
+   * This function is the same as `Arr.sort`, but for `NonEmptyArray`s.
+   *
+   * @param ord - The order is used to determine which element is greater
+   *
+   * @example
+   * ```ts
+   * const nbs = pipe(
+   *   [1,4,2,3],
+   *   NonEmptyArray.sort(Ord.number)
+   * )
+   *
+   * expect(nbs).toEqual([1,2,3,4])
+   * ```
+   */
+  sort
 }

--- a/packages/std/src/Option.ts
+++ b/packages/std/src/Option.ts
@@ -33,7 +33,7 @@ export const fromNullable = <T>(value: T | null): Option<T> => (value === null ?
 
 export const fromFalsy = <T>(value: T | Falsy): Option<T> => (!value ? undefined : value)
 
-export const fromString = (value: string): Option<string> => (value.length === 0 ? undefined : value)
+export const fromString = <T>(value: T | string): Option<T | string> => (value === '' ? undefined : value)
 
 export const fromNumber = (value: number): Option<number> => (isNaN(value) ? undefined : value)
 
@@ -54,11 +54,13 @@ export function reject(fn: any) {
   return filter(not(fn))
 }
 
-export function get<A>(onNone: () => A): (value: Option<A>) => A
-export function get<A>(defaultValue: A): (value: Option<A>) => A
+export function get(onNone: () => never): <A>(value: Option<A>) => never
+export function get(onNone: () => never[]): <A extends any[]>(value: Option<A>) => Some<A>
+export function get(defaultValue: never[]): <A extends any[]>(value: Option<A>) => Some<A>
+export function get<B>(onNone: () => B): <A>(value: Option<A>) => Some<A> | B
+export function get<B>(defaultValue: B): <A>(value: Option<A>) => Some<A> | B
 export function get(valueOrFn: unknown | (() => unknown)) {
-  return (value: Option<unknown>): unknown =>
-    isSome(value) ? value : typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn
+  return (value: Option<any>) => (isSome(value) ? value : typeof valueOrFn === 'function' ? valueOrFn() : valueOrFn)
 }
 
 export function throwError<A>(onNone: () => Error): (value: Option<A>) => A

--- a/packages/std/src/Ord.ts
+++ b/packages/std/src/Ord.ts
@@ -41,15 +41,25 @@ export const optional = <A>(ord: Ord<A>): Ord<Option<A>> => (a, b) =>
 export const nullable = <A>(ord: Ord<A>): Ord<A | null> => (a, b) =>
   a === b ? 0 : a !== null ? (b !== null ? ord(a, b) : -1) : 1
 
-export const concat = <A>(...ords: [Ord<A>, Ord<A>, ...Ord<A>[]]): Ord<A> => (a, b) => {
-  for (let i = 0; i < ords.length; ++i) {
-    const ord = ords[i]
-    const result = ord(a, b)
-    if (result !== 0) {
-      return result
+export function concat<A>(...ords: [Ord<A>]): Ord<A>
+export function concat<A, B>(...ords: [Ord<A>, Ord<B>]): Ord<A & B>
+export function concat<A, B, C>(...ords: [Ord<A>, Ord<B>, Ord<C>]): Ord<A & B & C>
+export function concat<A, B, C, D>(...ords: [Ord<A>, Ord<B>, Ord<C>, Ord<D>]): Ord<A & B & C & D>
+export function concat<A, B, C, D, E>(...ords: [Ord<A>, Ord<B>, Ord<C>, Ord<D>, Ord<E>]): Ord<A & B & C & D & E>
+export function concat<A, B, C, D, E, F>(
+  ...ords: [Ord<A>, Ord<B>, Ord<C>, Ord<D>, Ord<E>, Ord<F>]
+): Ord<A & B & C & D & E & F>
+export function concat(...ords: [Ord<any>, ...Ord<any>[]]): Ord<any> {
+  return (a, b) => {
+    for (let i = 0; i < ords.length; ++i) {
+      const ord = ords[i]
+      const result = ord(a, b)
+      if (result !== 0) {
+        return result
+      }
     }
+    return 0
   }
-  return 0
 }
 
 export const eq = <A>(ord: Ord<A>) =>

--- a/packages/std/src/String.ts
+++ b/packages/std/src/String.ts
@@ -41,6 +41,9 @@ export const truncate = (maxLength: number, suffix = '...') => (str: string) =>
 export const replace = (regexp: RegExp | string, replacer: string | Str.Replacer) => (str: string) =>
   str.replace(regexp, replacer as any)
 
+export const replaceAll = (regexp: string, replacer: string | Str.Replacer) =>
+  replace(new RegExp(regexp, 'g'), replacer)
+
 export const regexpEscape = flow(replace(/[|\\{}()[\]^$+*?.]/g, '\\$&'), replace(/-/g, '\\x2d'))
 
 export const htmlEscape = flow(
@@ -231,20 +234,37 @@ export const Str = {
 
   /**
    * @description
-   * Replace occurences in a string.
+   * Replace first occurence (or all if a global RegExp has been specified) in a string.
    * This function is the pipeable equivalent to the native replace function.
    *
    * @example
    * ```ts
    * const str = pipe(
-   *   'Hello John',
+   *   'Hello John, John',
    *   Str.replace('John', 'Doe')
    * )
    *
-   * expect(str).toBe('Hello Doe')
+   * expect(str).toBe('Hello Doe, John')
    * ```
    */
   replace,
+
+  /**
+   * @description
+   * Replace all occurences in a string.
+   * This function is the pipeable equivalent to the native replaceAll function.
+   *
+   * @example
+   * ```ts
+   * const str = pipe(
+   *   'Hello John, John',
+   *   Str.replaceAll('John', 'Doe')
+   * )
+   *
+   * expect(str).toBe('Hello Doe, Doe')
+   * ```
+   */
+  replaceAll,
 
   /**
    * @description

--- a/packages/std/tests/Option.ts
+++ b/packages/std/tests/Option.ts
@@ -194,6 +194,12 @@ describe('Option.get', () => {
 describe('Option.throwError', () => {
   it('should throw if undefined', () => {
     expect(() => pipe(undefined, Option.throwError(Err.of('Undefined variable')))).toThrowError('Undefined variable')
+    expect(() =>
+      pipe(
+        undefined,
+        Option.throwError(() => Err.of('Undefined variable'))
+      )
+    ).toThrowError('Undefined variable')
   })
   it('should return value if defined', () => {
     expect(pipe(0, Option.throwError(Err.of('Undefined variable')))).toBe(0)

--- a/packages/std/tests/String.ts
+++ b/packages/std/tests/String.ts
@@ -68,7 +68,14 @@ describe('String.template', () => {
 
 describe('String.replace', () => {
   it('should return expected result', () => {
-    expect(pipe('Hello world', Str.replace(/o/g, 'a'))).toBe('Hella warld')
+    expect(pipe('Hello world! Hello John!', Str.replace('Hello', 'Hey'))).toBe('Hey world! Hello John!')
+    expect(pipe('Hello world! Hello John!', Str.replace(/Hello/g, 'Hey'))).toBe('Hey world! Hey John!')
+  })
+})
+
+describe('String.replaceAll', () => {
+  it('should return expected result', () => {
+    expect(pipe('Hello world! Hello John!', Str.replaceAll('Hello', 'Hey'))).toBe('Hey world! Hey John!')
   })
 })
 

--- a/packages/std/tests/function.ts
+++ b/packages/std/tests/function.ts
@@ -1,4 +1,4 @@
-import { add, Arr, Dict, identity, not, pipe, throwError, tuple, tupled, untupled } from '../src'
+import { add, Arr, Dict, identity, not, pipe, run, throwError, tuple, tupled, untupled } from '../src'
 
 describe('add', () => {
   it('should addition 2 numbers', () => {
@@ -71,5 +71,11 @@ describe('untupled', () => {
 describe('throwError', () => {
   it('should throw', () => {
     expect(() => throwError('error')).toThrow('error')
+  })
+})
+
+describe('run', () => {
+  it('should run', () => {
+    expect(run(() => 1)).toEqual(1)
   })
 })


### PR DESCRIPTION
**Features**:

- Better typing for `Option.get`
- Better typing for `Option.fromString`

- Better typing for `Arr.sort`:
```ts
const ordCreatedAt = pipe(
  Ord.date,
  Ord.inverse,
  Ord.contramap((item: { createdAt: Date }) => item.createdAt)
)

interface Contact {
  id: string
  createdAt: Date
}
const contacts: Contact[] = [...]

// Now returns Contact[] instead of { createdAt: Date }[]
const sorted = pipe(
  contacts,
  Arr.sort(ordCreatedAt)
)
```

- Better typing for `Ord.concat`
```ts
const ordUpdatedAt = pipe(
  Ord.date,
  Ord.inverse,
  Ord.contramap((item: { updatedAt: Date }) => item.updatedAt)
)
const ordCreatedAt = pipe(
  Ord.date,
  Ord.inverse,
  Ord.contramap((item: { createdAt: Date }) => item.createdAt)
)

// ordTimestamp is now Ord<{ updatedAt: Date, createdAt: Date }>
const ordTimestamp = Ord.concat(ordUpdated, ordCreated)
```


- Add `Str.replaceAll`
- Add `NonEmptyArray.sort`