### PR TITLE
feat(decoders)!: add new date decoders

### DIFF
--- a/packages/csv/package.json
+++ b/packages/csv/package.json
@@ -37,7 +37,7 @@
     "papaparse": "^5.3.0"
   },
   "devDependencies": {
-    "@apoyo/decoders": "^0.0.9",
+    "@apoyo/decoders": "^0.0.10",
     "@apoyo/std": "^0.0.10",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",

--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/decoders",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Validation utilities",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/packages/decoders/src/Errors.ts
+++ b/packages/decoders/src/Errors.ts
@@ -5,6 +5,7 @@ export const enum ErrorCode {
   STRING_LENGTH = 'string.length',
   STRING_MIN = 'string.min',
   STRING_MAX = 'string.max',
+  STRING_PATTERN = 'string.pattern',
   STRING_EMAIL = 'string.email',
   STRING_UUID = 'string.uuid',
   STRING_EQUALS = 'string.equals',
@@ -13,6 +14,9 @@ export const enum ErrorCode {
   STRING_DATETIME = 'string.datetime',
 
   DATE = 'date',
+  DATE_STRICT = 'date.strict',
+  DATE_MIN = 'date.min',
+  DATE_MAX = 'date.max',
 
   NUMBER = 'number',
   NUMBER_STRICT = 'number.strict',


### PR DESCRIPTION
**Features:**
- create `TextDecoder.date`
- create `TextDecoder.datetime`
- add `DateDecoder.strict` 
- add `DateDecoder.min`
- add `DateDecoder.max`

**Breaking changes:**
- `DateDecoder.date` now returns a `Date` object instead of a string
- `DateDecoder.datetime` now returns a `Date` object instead of a string