### PR TITLE
feat(std): improvements on Arr / Dict / Obj

### DIFF
--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/std",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Typescript utility library",
   "main": "lib/index.js",
   "module": "es6/index.js",

--- a/packages/std/src/Array.ts
+++ b/packages/std/src/Array.ts
@@ -140,9 +140,7 @@ export const chunksOf = (size: number) => <A>(arr: A[]) => {
   return chunks
 }
 
-export function uniq(arr: string[]): string[]
-export function uniq(arr: number[]): number[]
-export function uniq(arr: any[]) {
+export function uniq<T extends string | number>(arr: T[] | readonly T[]): T[] {
   return from(new Set(arr))
 }
 

--- a/packages/std/src/Object.ts
+++ b/packages/std/src/Object.ts
@@ -36,10 +36,21 @@ export function pick(props: string[]) {
   return Dict.filter((_, key) => propsSet.has(key))
 }
 
+export const compact = <A extends Obj>(obj: A): A => {
+  const out: A = { ...obj }
+  for (const key in out) {
+    if (key === undefined) {
+      delete out[key]
+    }
+  }
+  return out
+}
+
 export const Obj = {
   copy,
   merge,
   property,
   omit,
-  pick
+  pick,
+  compact
 }

--- a/packages/std/src/Object.ts
+++ b/packages/std/src/Object.ts
@@ -24,16 +24,12 @@ export const property = (path: string) => (obj: Dict.Dict<any>) =>
     reduce((obj, prop) => (obj ? obj[prop] : undefined), obj)
   )
 
-export function omit<A extends Obj, B extends keyof A>(props: B[]): (obj: A) => Omit<A, B>
-export function omit(props: string[]) {
-  const propsSet = new Set(props)
-  return Dict.reject((_, key) => propsSet.has(key))
+export const omit = Dict.omit as {
+  <A extends Obj, B extends keyof A>(props: B[]): (obj: A) => Omit<A, B>
 }
 
-export function pick<A extends Obj, B extends keyof A>(props: B[]): (obj: A) => Pick<A, B>
-export function pick(props: string[]) {
-  const propsSet = new Set(props)
-  return Dict.filter((_, key) => propsSet.has(key))
+export const pick = Dict.pick as {
+  <A extends Obj, B extends keyof A>(props: B[]): (obj: A) => Pick<A, B>
 }
 
 export const compact = <A extends Obj>(obj: A): A => {

--- a/packages/std/tests/Array.ts
+++ b/packages/std/tests/Array.ts
@@ -360,6 +360,19 @@ describe('Array.uniq', () => {
     const expected = [1, 2, 3, 5, 4]
     expect(b).toEqual(expected)
   })
+
+  it('should work correctly with both strings and numbers', () => {
+    expect(pipe([1, 2, 3], Arr.uniq)).toEqual([1, 2, 3])
+    expect(pipe(['1', '2', '3'], Arr.uniq)).toEqual(['1', '2', '3'])
+  })
+
+  it('should work with constants', () => {
+    const a: (1 | 2 | 3)[] = pipe([1, 2, 3, 3] as const, Arr.uniq)
+    const b: ('1' | '2' | '3')[] = pipe(['1', '2', '3', '3'] as const, Arr.uniq)
+
+    expect(a).toEqual([1, 2, 3])
+    expect(b).toEqual(['1', '2', '3'])
+  })
 })
 
 describe('Array.uniqBy', () => {

--- a/packages/std/tests/Dict.ts
+++ b/packages/std/tests/Dict.ts
@@ -1,4 +1,4 @@
-import { pipe, Dict, isNull, or, isUndefined, Option, identity } from '../src'
+import { pipe, Dict, isNull, or, isUndefined, Option, identity, Arr } from '../src'
 
 describe('Dict.isEmpty', () => {
   it('should be true when empty', () => {
@@ -160,6 +160,112 @@ describe('Dict.compact', () => {
     expect(res).toEqual({
       firstName: 'John',
       lastName: null
+    })
+  })
+})
+
+describe('Dict.fromPairs', () => {
+  it('should create a dict from pairs', () => {
+    interface Todo {
+      id: number
+      title: string
+    }
+    const todos: Todo[] = [
+      {
+        id: 1,
+        title: 'test'
+      },
+      {
+        id: 2,
+        title: 'test2'
+      }
+    ]
+
+    const res: Dict<Todo> = pipe(
+      todos,
+      Arr.map((todo) => [todo.id, todo] as const),
+      Dict.fromPairs
+    )
+
+    expect(res).toEqual({
+      1: todos[0],
+      2: todos[1]
+    })
+  })
+})
+
+describe('Dict.concat', () => {
+  it('should concat dicts correctly', () => {
+    const merged = pipe(
+      {
+        firstName: 'John',
+        lastName: 'Doe'
+      },
+      Dict.concat({
+        lastName: 'Smith',
+        gender: 'M'
+      })
+    )
+    expect(merged).toEqual({
+      firstName: 'John',
+      lastName: 'Smith',
+      gender: 'M'
+    })
+  })
+})
+
+describe('Dict.union', () => {
+  it('should merge dicts correctly', () => {
+    const merged = pipe(
+      {
+        firstName: 'John',
+        lastName: 'Doe'
+      },
+      Dict.union({
+        lastName: 'Smith',
+        gender: 'M'
+      })
+    )
+    expect(merged).toEqual({
+      firstName: 'John',
+      lastName: 'Doe',
+      gender: 'M'
+    })
+  })
+})
+
+describe('Dict.intersect', () => {
+  it('should return expected results', () => {
+    const intersection = pipe(
+      {
+        firstName: 'John',
+        lastName: 'Doe'
+      },
+      Dict.intersect({
+        lastName: 'Smith',
+        gender: 'M'
+      })
+    )
+    expect(intersection).toEqual({
+      lastName: 'Doe'
+    })
+  })
+})
+
+describe('Dict.difference', () => {
+  it('should return expected results', () => {
+    const diff = pipe(
+      {
+        firstName: 'John',
+        lastName: 'Doe'
+      },
+      Dict.difference({
+        lastName: 'Smith',
+        gender: 'M'
+      })
+    )
+    expect(diff).toEqual({
+      firstName: 'John'
     })
   })
 })

--- a/packages/std/tests/Object.ts
+++ b/packages/std/tests/Object.ts
@@ -73,7 +73,9 @@ describe('Object.property', () => {
 describe('Object.omit', () => {
   it('should omit props', () => {
     const source = { firstName: 'John', lastName: 'Doe' }
-    const res = pipe(source, Obj.omit(['lastName']))
+    const res: {
+      firstName: string
+    } = pipe(source, Obj.omit(['lastName']))
     expect(res !== source).toBe(true)
     expect(res).toEqual({
       firstName: 'John'
@@ -84,7 +86,9 @@ describe('Object.omit', () => {
 describe('Object.pick', () => {
   it('should omit props', () => {
     const source = { firstName: 'John', lastName: 'Doe' }
-    const res = pipe(source, Obj.pick(['lastName']))
+    const res: {
+      lastName: string
+    } = pipe(source, Obj.pick(['lastName']))
     expect(res !== source).toBe(true)
     expect(res).toEqual({
       lastName: 'Doe'

--- a/packages/std/tests/Object.ts
+++ b/packages/std/tests/Object.ts
@@ -91,3 +91,24 @@ describe('Object.pick', () => {
     })
   })
 })
+
+describe('Object.compact', () => {
+  it('should remove enumerable keys with undefined values', () => {
+    const input: Partial<{ firstName: string; lastName: string }> = { firstName: 'John', lastName: undefined }
+    const res = Obj.compact({ firstName: 'John' })
+
+    expect(input).toEqual(res)
+  })
+
+  it('should keep symbols', () => {
+    const sym = Symbol('test')
+    const input: Partial<{ [sym]: boolean; firstName: string; lastName: string }> = {
+      [sym]: true,
+      firstName: 'John',
+      lastName: undefined
+    }
+    const res = Obj.compact({ [sym]: true, firstName: 'John' })
+
+    expect(input).toEqual(res)
+  })
+})


### PR DESCRIPTION
version 0.0.12 (No breaking changes)

**Features**:

- Fix `Arr.uniq` typings
- Fix `Dict.fromPairs` typings to access readonly

- Add `Dict.get` (alias for `Dict.lookup` for now)
- Add `Dict.concat`
- Add `Dict.omit`
- Add `Dict.pick`
- Add `Obj.compact`

- Add missing unit tests