### PR TITLE
feat(decoders): default value operator + object decoder improvements

### DIFF
--- a/packages/decoders/package.json
+++ b/packages/decoders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/decoders",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Validation utilities",
   "main": "lib/index.js",
   "module": "es6/index.js",
@@ -32,7 +32,7 @@
     "build": "npx tsc -p ./tsconfig.common.json && npx tsc -p ./tsconfig.es.json && npx ts-node ../../scripts/build"
   },
   "devDependencies": {
-    "@apoyo/std": "^0.0.11",
+    "@apoyo/std": "^0.0.12",
     "@types/jest": "^26.0.23",
     "@types/node": "^12.6.8",
     "jest": "^26.4.2",

--- a/packages/decoders/src/Decoder.ts
+++ b/packages/decoders/src/Decoder.ts
@@ -60,7 +60,7 @@ export const optional = <I, O>(decoder: Decoder<I, O>): Decoder<I, O | undefined
 
 export const required = <I, O>(decoder: Decoder<I, O>): Decoder<I, O | undefined> =>
   create((input: any) =>
-    input === undefined || input === null || input === ''
+    input === undefined || input === null
       ? Result.ko(DecodeError.value(input, 'input is required', { code: ErrorCode.REQUIRED }))
       : pipe(input, validate(decoder))
   )

--- a/packages/decoders/src/Decoder.ts
+++ b/packages/decoders/src/Decoder.ts
@@ -251,9 +251,8 @@ export const Decoder = {
    *
    * @example
    * ```ts
-   * const validateAge = (dob: string): Result<string, DecodeError> => {
+   * const validateAge = (date: Date): Result<string, DecodeError> => {
    *   const now = new Date()
-   *   const date = new Date(dob)
    *
    *   if (date.getFullYear() < now.getFullYear() - 100) {
    *     return Result.ko(DecodeError.value(dob, 'Date of birth is more than 100 years ago'))

--- a/packages/decoders/src/ObjectDecoder.ts
+++ b/packages/decoders/src/ObjectDecoder.ts
@@ -10,7 +10,7 @@ export type ObjectDecoder<I, O extends Dict> = Decoder<I, O> & {
 }
 
 type Struct<A extends Dict<unknown>> = {
-  [P in keyof A]: Decoder<unknown, A[P]>
+  [P in keyof A]-?: Decoder<unknown, A[P]>
 }
 
 const create = <I, O extends Dict>(props: Dict, decoder: Decoder<I, O>): ObjectDecoder<I, O> => ({

--- a/packages/decoders/src/ObjectDecoder.ts
+++ b/packages/decoders/src/ObjectDecoder.ts
@@ -61,6 +61,7 @@ export const struct = <A extends Dict>(props: Struct<A>, name?: string): ObjectD
                 Result.mapError((err) => DecodeError.key(key, err))
               )
             ),
+            Result.map(Dict.compact),
             Result.mapError((errors) => DecodeError.object(errors, name))
           ) as Result<A, DecodeError>
       )

--- a/packages/decoders/tests/Decoder.spec.ts
+++ b/packages/decoders/tests/Decoder.spec.ts
@@ -99,6 +99,29 @@ describe('Decoder.nullable', () => {
   })
 })
 
+describe('Decoder.default', () => {
+  it('should return expected results', () => {
+    const decoder: Decoder<unknown, string | null> = pipe(TextDecoder.string, Decoder.nullable, Decoder.default(null))
+
+    expect(pipe('text', Decoder.validate(decoder), Result.get)).toBe('text')
+    expect(pipe(null, Decoder.validate(decoder), Result.get)).toBe(null)
+    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe(null)
+  })
+
+  it('should be overridable by another optional operator', () => {
+    const decoder: Decoder<unknown, string | null | undefined> = pipe(
+      TextDecoder.string,
+      Decoder.nullable,
+      Decoder.default(null),
+      Decoder.optional
+    )
+
+    expect(pipe('text', Decoder.validate(decoder), Result.get)).toBe('text')
+    expect(pipe(null, Decoder.validate(decoder), Result.get)).toBe(null)
+    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe(undefined)
+  })
+})
+
 describe('Decoder.lazy', () => {
   interface Tree<T> {
     value: T

--- a/packages/decoders/tests/Decoder.spec.ts
+++ b/packages/decoders/tests/Decoder.spec.ts
@@ -108,6 +108,13 @@ describe('Decoder.default', () => {
     expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe(null)
   })
 
+  it('should type correctly when defaulting an empty array', () => {
+    const decoder: Decoder<unknown, string[]> = pipe(ArrayDecoder.array(TextDecoder.string), Decoder.default([]))
+
+    expect(pipe(['text'], Decoder.validate(decoder), Result.get)).toBe(['text'])
+    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe([])
+  })
+
   it('should be overridable by another optional operator', () => {
     const decoder: Decoder<unknown, string | null | undefined> = pipe(
       TextDecoder.string,

--- a/packages/decoders/tests/Decoder.spec.ts
+++ b/packages/decoders/tests/Decoder.spec.ts
@@ -89,13 +89,13 @@ describe('Decoder.optional', () => {
 
 describe('Decoder.nullable', () => {
   it('should succeed', () => {
-    expect(pipe(42, Decoder.validate(NumberDecoder.number), Result.isOk)).toBe(true)
-    expect(pipe(null, Decoder.validate(Decoder.nullable(NumberDecoder.number)), Result.isOk)).toBe(true)
+    expect(pipe(42, Decoder.validate(Decoder.nullable(NumberDecoder.number)), Result.get)).toBe(42)
+    expect(pipe(null, Decoder.validate(Decoder.nullable(NumberDecoder.number)), Result.get)).toBe(null)
+    expect(pipe(undefined, Decoder.validate(Decoder.nullable(NumberDecoder.number)), Result.get)).toBe(null)
   })
 
   it('should fail', () => {
     expect(pipe(null, Decoder.validate(NumberDecoder.number), Result.isKo)).toBe(true)
-    expect(pipe(undefined, Decoder.validate(Decoder.nullable(NumberDecoder.number)), Result.isKo)).toBe(true)
   })
 })
 
@@ -111,8 +111,8 @@ describe('Decoder.default', () => {
   it('should type correctly when defaulting an empty array', () => {
     const decoder: Decoder<unknown, string[]> = pipe(ArrayDecoder.array(TextDecoder.string), Decoder.default([]))
 
-    expect(pipe(['text'], Decoder.validate(decoder), Result.get)).toBe(['text'])
-    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe([])
+    expect(pipe(['text'], Decoder.validate(decoder), Result.get)).toEqual(['text'])
+    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toEqual([])
   })
 
   it('should be overridable by another optional operator', () => {

--- a/packages/decoders/tests/ObjectDecoder.spec.ts
+++ b/packages/decoders/tests/ObjectDecoder.spec.ts
@@ -52,8 +52,20 @@ describe('ObjectDecoder.struct', () => {
       }
     ]
 
-    expect(pipe(todos[0], Decoder.validate(TodoDto), Result.isOk)).toBe(true)
-    expect(pipe(todos[1], Decoder.validate(TodoDto), Result.isOk)).toBe(true)
+    const out1 = pipe(todos[0], Decoder.validate(TodoDto), Result.get)
+    const out2 = pipe(todos[1], Decoder.validate(TodoDto), Result.get)
+
+    expect(out1).toEqual({
+      id: 2,
+      title: 'Eat breakfast',
+      done: false,
+      description: 'A delicious bread with Nutella'
+    })
+    expect(out2).toEqual({
+      id: 1,
+      title: 'Wake up',
+      done: true
+    })
   })
 
   it('should strip additional fields', () => {
@@ -99,6 +111,23 @@ describe('ObjectDecoder.struct', () => {
       done: true
     }
     expect(pipe(todo, Decoder.validate(TodoDto), Result.isKo)).toBe(true)
+  })
+
+  it('should remove field with undefined value', () => {
+    const todo: TodoDto = {
+      id: 1,
+      title: 'Wake up',
+      done: true,
+      description: undefined
+    }
+
+    const out = pipe(todo, Decoder.validate(TodoDto), Result.get)
+
+    expect(out).toEqual({
+      id: 1,
+      title: 'Wake up',
+      done: true
+    })
   })
 })
 
@@ -154,7 +183,7 @@ describe('ObjectDecoder.partial', () => {
 
   it('should succeed without any properties', () => {
     const todo: TodoPutDto = {}
-    expect(pipe(todo, Decoder.validate(TodoPutDto), Result.isOk)).toBe(true)
+    expect(pipe(todo, Decoder.validate(TodoPutDto), Result.get)).toEqual({})
   })
 
   it('should succeed with properties', () => {

--- a/packages/decoders/tests/ObjectDecoder.spec.ts
+++ b/packages/decoders/tests/ObjectDecoder.spec.ts
@@ -37,6 +37,24 @@ const TodoDto = ObjectDecoder.struct({
 interface TodoDto extends Decoder.TypeOf<typeof TodoDto> {}
 
 describe('ObjectDecoder.struct', () => {
+  it('should enforce type correctly', () => {
+    interface TodoDto {
+      id: number
+      title: string
+      done: boolean
+      description?: string | null
+    }
+
+    const TodoDto = ObjectDecoder.struct<TodoDto>({
+      id: NumberDecoder.number,
+      title: TextDecoder.varchar(1, 100),
+      done: BooleanDecoder.boolean,
+      description: pipe(TextDecoder.varchar(0, 1000), TextDecoder.nullable, Decoder.optional)
+    })
+
+    expect(true).toBe(true)
+  })
+
   it('should succeed', () => {
     const todos: TodoDto[] = [
       {

--- a/packages/decoders/tests/ObjectDecoder.spec.ts
+++ b/packages/decoders/tests/ObjectDecoder.spec.ts
@@ -45,6 +45,15 @@ describe('ObjectDecoder.struct', () => {
       description?: string | null
     }
 
+    // Should fail
+    // @ts-expect-error Missing decoder for "description" property
+    ObjectDecoder.struct<TodoDto>({
+      id: NumberDecoder.number,
+      title: TextDecoder.varchar(1, 100),
+      done: BooleanDecoder.boolean
+    })
+
+    // Should be valid
     const TodoDto = ObjectDecoder.struct<TodoDto>({
       id: NumberDecoder.number,
       title: TextDecoder.varchar(1, 100),

--- a/packages/decoders/tests/TextDecoder.spec.ts
+++ b/packages/decoders/tests/TextDecoder.spec.ts
@@ -117,10 +117,11 @@ describe('TextDecoder.nullable', () => {
     expect(pipe('Test', Decoder.validate(decoder), Result.get)).toBe('Test')
     expect(pipe('', Decoder.validate(decoder), Result.get)).toBe(null)
     expect(pipe(null, Decoder.validate(decoder), Result.get)).toBe(null)
+    expect(pipe(undefined, Decoder.validate(decoder), Result.get)).toBe(null)
   })
 
   it('should fail', () => {
-    expect(pipe(undefined, Decoder.validate(decoder), Result.isKo)).toBe(true)
+    expect(pipe(42, Decoder.validate(decoder), Result.isKo)).toBe(true)
   })
 })
 


### PR DESCRIPTION
@apoyo/decoder@0.0.12:

**Features**:

- Add `Decoder.default`

- `ObjectDecoder.struct` and other operators of `ObjectDecoder` now remove properties with undefined value (as with `Dict.compact`)

Example:
```ts
// Before, object decoders returned properties with "undefined"
{
  id: "xxxx",
  title: "Wake up",
  description: undefined
}

// Now, the properties with "undefined" values are removed. This makes partial updating easier, by avoiding updating values that have not changed.
{
  id: "xxxx",
  title: "Wake up"
}
```

- Fixed `ObjectDecoder.struct` type enforcing

```ts
interface Todo {
  id: string
  title: string
  description: string | null
}

// Now ObjectDecoder.struct<Todo> enforces "description" property correctly
const TodoDto = ObjectDecoder.struct<Todo>({
  id: TextDecoder.uuid,
  title: TextDecoder.varchar(1, 255),
  description: pipe(
    TextDecoder.varchar(0, 2000),
    TextDecoder.nullable
  )
})
```

EDIT 1 (31/01/22):

- `Decoder.nullable` also makes `Decoder` optional now. As such, if the input is undefined, the `Decoder` will return null from now on.