### PR TITLE
feat(files): add framework agnostic file drivers based on adonisjs drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ The goal was having:
 
 - [Decoders](packages/decoders) (`@apoyo/decoders`): Contains type decoders and validators.
 
+- [Files](packages/files) (`@apoyo/files`): Contains file drivers for most commonly used providers.
+
+<!--
+Packages that are not ready yet:
+
 - [Scopes](packages/scopes) (`@apoyo/scopes`): A simple functional dependency injector.
 
-- [Http](packages/process) (`@apoyo/process`): Contains Nodejs process utils, such as auto-loading .env files, validating and parsing environment variables, a zero-config logger (using pino), etc...
+- [Process](packages/process) (`@apoyo/process`): Contains Nodejs process utils, such as auto-loading .env files, validating and parsing environment variables, a zero-config logger (using pino), etc...
+
+-->
 
 ## Setup
 

--- a/packages/files-azure/CHANGELOG.md
+++ b/packages/files-azure/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/files-azure/LICENSE
+++ b/packages/files-azure/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/files-azure/README.md
+++ b/packages/files-azure/README.md
@@ -1,6 +1,6 @@
-# Apoyo - Files (GCS Driver)
+# Apoyo - Files (Azure Driver)
 
-[![npm version](https://badgen.net/npm/v/@apoyo/files-gcs)](https://www.npmjs.com/package/@apoyo/files-gcs)
+[![npm version](https://badgen.net/npm/v/@apoyo/files-azure)](https://www.npmjs.com/package/@apoyo/files-azure)
 
 ## Installation
 
@@ -8,11 +8,11 @@ Install peer dependencies:
 `npm install @apoyo/files @apoyo/std`
 
 Install package:
-`npm install @apoyo/files-gcs`
+`npm install @apoyo/files-azure`
 
 ## Introduction
 
-This library is a simplfied framework agnostic version of [Adonisjs GCS Drive](https://github.com/adonisjs/drive-gcs).
+This library is a simplified framework agnostic version of [Adonisjs Azure Drive](https://github.com/AlexanderYW/Adonis-Drive-Azure-Storage).
 
 Please check out [@apoyo/files](https://github.com/neoxia/apoyo/tree/master/packages/files) for more information.
 

--- a/packages/files-azure/jest.config.js
+++ b/packages/files-azure/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/files-azure/package.json
+++ b/packages/files-azure/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@apoyo/files-azure",
+  "version": "0.0.1",
+  "description": "File driver for Azure Storage",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "tags": [
+    "utils",
+    "files",
+    "drive",
+    "azure"
+  ],
+  "keywords": [
+    "utils",
+    "files",
+    "drive",
+    "azure"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-azure",
+  "scripts": {
+    "test": "jest --verbose --runInBand",
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@apoyo/files": "0.0.1",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^14.18.21",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@apoyo/files": "0.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@azure/identity": "^2.1.0",
+    "@azure/storage-blob": "^12.11.0"
+  }
+}

--- a/packages/files-azure/package.json
+++ b/packages/files-azure/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-azure",
   "scripts": {
-    "test": "jest --verbose --runInBand",
+    "test": "jest --verbose --runInBand --passWithNoTests",
     "build": "tsup"
   },
   "devDependencies": {

--- a/packages/files-azure/src/drivers/azure.ts
+++ b/packages/files-azure/src/drivers/azure.ts
@@ -1,0 +1,274 @@
+import {
+  CannotCopyFileException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  CannotWriteFileException,
+  CannotDeleteFileException,
+  CannotGetMetaDataException,
+  DriverContract
+} from '@apoyo/files'
+
+import { DriveFileStats } from '@apoyo/files'
+
+import { DefaultAzureCredential } from '@azure/identity'
+import {
+  newPipeline,
+  BlobServiceClient,
+  StorageSharedKeyCredential,
+  BlobDownloadOptions,
+  BlobDownloadToBufferOptions,
+  BlobExistsOptions,
+  BlobSASPermissions,
+  generateBlobSASQueryParameters,
+  BlobSASSignatureValues,
+  BlockBlobUploadOptions,
+  BlockBlobUploadStreamOptions,
+  BlockBlobClient,
+  CommonOptions
+} from '@azure/storage-blob'
+import { ReadStream } from 'fs'
+
+export type AzureDriverConfig = CommonOptions & {
+  connectionString?: string
+  azureTenantId?: string
+  azureClientId?: string
+  azureClientSecret?: string
+  name?: string
+  key?: string
+  localAddress?: string
+  container?: string
+}
+
+export class AzureDriver implements DriverContract {
+  /**
+   * Reference to the Azure storage instance
+   */
+  public adapter: BlobServiceClient
+
+  /**
+   * Name of the driver
+   */
+  public name: 'azure' = 'azure'
+
+  constructor(private _config: AzureDriverConfig) {
+    if (_config.connectionString) {
+      // eslint-disable-next-line
+      this.adapter = BlobServiceClient.fromConnectionString(
+        _config.connectionString
+      )
+    } else {
+      let credential: any
+      if (_config.azureTenantId && _config.azureClientId && _config.azureClientSecret) {
+        credential = new DefaultAzureCredential()
+      } else if (_config.name && _config.key) {
+        credential = new StorageSharedKeyCredential(_config.name, _config.key)
+      }
+
+      let url = `https://${this._config.name}.blob.core.windows.net`
+
+      if (typeof this._config.localAddress !== 'undefined') {
+        url = this._config.localAddress
+      }
+
+      const azurePipeline = newPipeline(credential)
+
+      this.adapter = new BlobServiceClient(url, azurePipeline)
+    }
+  }
+
+  public getBlockBlobClient(location: string) {
+    const container = this._config.container as string
+
+    const containerClient = this.adapter.getContainerClient(container)
+    return containerClient.getBlockBlobClient(location)
+  }
+
+  public async generateBlobSASURL(blockBlobClient: BlockBlobClient, options: BlobSASSignatureValues): Promise<string> {
+    options.permissions =
+      options.permissions === undefined || typeof options.permissions === 'string'
+        ? BlobSASPermissions.parse(options.permissions || 'r')
+        : options.permissions
+
+    options.startsOn = options.startsOn || new Date()
+    options.expiresOn = options.expiresOn || new Date(options.startsOn.valueOf() + 3600 * 1000)
+
+    const factories = (blockBlobClient as any).pipeline.factories
+    const credential = factories[factories.length - 1] as StorageSharedKeyCredential
+
+    const blobSAS = await generateBlobSASQueryParameters(
+      {
+        containerName: blockBlobClient.containerName, // Required
+        blobName: blockBlobClient.name, // Required
+        permissions: options.permissions, // Required
+        startsOn: options.startsOn,
+        expiresOn: options.expiresOn
+      },
+      credential
+    )
+
+    return `${blockBlobClient.url}?${blobSAS.toString()}`
+  }
+
+  /**
+   * Returns the file contents as a buffer. The buffer return
+   * value allows you to self choose the encoding when
+   * converting the buffer to a string.
+   */
+  public async get(location: string, options: BlobDownloadToBufferOptions | any = {}): Promise<Buffer> {
+    try {
+      const blockBlobClient = this.getBlockBlobClient(location)
+      return await blockBlobClient.downloadToBuffer(0, 0, options)
+    } catch (error) {
+      throw new CannotReadFileException(location, error)
+    }
+  }
+
+  /**
+   * Returns the file contents as a stream
+   */
+  public async getStream(location: string, options: BlobDownloadOptions | any = {}): Promise<NodeJS.ReadableStream> {
+    const response = await this.getBlockBlobClient(location).download(0, 0, options)
+    return response.readableStreamBody as NodeJS.ReadableStream
+  }
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  public exists(location: string, options: BlobExistsOptions | any = {}): Promise<boolean> {
+    try {
+      return this.getBlockBlobClient(location).exists(options)
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'exists', error)
+    }
+  }
+
+  /**
+   * Returns the signed url for a given path
+   */
+  public async getSignedUrl(location: string, options?: BlobSASSignatureValues): Promise<string> {
+    options = options || {
+      containerName: this._config.container as string
+    }
+    options.containerName = options.containerName || (this._config.container as string)
+
+    try {
+      const blockBlobClient = this.getBlockBlobClient(location)
+      const SASUrl = await this.generateBlobSASURL(blockBlobClient, options)
+      return SASUrl
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'signedUrl', error)
+    }
+  }
+
+  /**
+   * Returns URL to a given path
+   */
+  public async getUrl(location: string): Promise<string> {
+    return unescape(this.getBlockBlobClient(location).url)
+  }
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   *
+   * @todo look into returning the response of upload
+   */
+  public async put(
+    location: string,
+    contents: Buffer | string,
+    options?: BlockBlobUploadOptions | undefined
+  ): Promise<void> {
+    const blockBlobClient = this.getBlockBlobClient(location)
+    try {
+      await blockBlobClient.upload(contents, contents.length, options)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  public async putStream(
+    location: string,
+    contents: ReadStream,
+    options?: BlockBlobUploadStreamOptions
+  ): Promise<void> {
+    const blockBlobClient = this.getBlockBlobClient(location)
+
+    try {
+      await blockBlobClient.uploadStream(contents, undefined, undefined, options)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   *
+   * @todo look into returning the response of syncCopyFromURL
+   */
+  public async copy(source: string, destination: string, options?: BlobSASSignatureValues): Promise<void> {
+    options = options || {
+      containerName: this._config.container as string
+    }
+    options.containerName = options.containerName || (this._config.container as string)
+
+    const sourceBlockBlobClient = this.getBlockBlobClient(source)
+    const destinationBlockBlobClient = this.getBlockBlobClient(destination)
+
+    const url = await this.generateBlobSASURL(sourceBlockBlobClient, options)
+
+    try {
+      await destinationBlockBlobClient.syncCopyFromURL(url)
+    } catch (error) {
+      throw new CannotCopyFileException(source, destination, error.original || error)
+    }
+  }
+
+  /**
+   * Remove a given location path
+   *
+   * @todo find a way to extend delete with BlobDeleteOptions
+   */
+  public async delete(location: string): Promise<void> {
+    try {
+      await this.getBlockBlobClient(location).delete()
+    } catch (error) {
+      throw new CannotDeleteFileException(location, error)
+    }
+  }
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async move(source: string, destination: string, options?: BlobSASSignatureValues): Promise<void> {
+    try {
+      await this.copy(source, destination, options)
+      await this.delete(source)
+    } catch (error) {
+      throw new CannotMoveFileException(source, destination, error.original || error)
+    }
+  }
+
+  /**
+   * Returns the file stats
+   */
+  public async getStats(location: string): Promise<DriveFileStats> {
+    try {
+      const metaData = await this.getBlockBlobClient(location).getProperties()
+
+      return {
+        modified: metaData.lastModified!,
+        size: metaData.contentLength!,
+        isFile: true,
+        etag: metaData.etag
+      }
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'stats', error)
+    }
+  }
+}

--- a/packages/files-azure/src/index.ts
+++ b/packages/files-azure/src/index.ts
@@ -1,0 +1,1 @@
+export { AzureDriver, AzureDriverConfig } from './drivers/azure'

--- a/packages/files-azure/tests/process.spec.ts
+++ b/packages/files-azure/tests/process.spec.ts
@@ -1,5 +1,0 @@
-describe('Files', () => {
-  it('should return ok', async () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/files-azure/tests/process.spec.ts
+++ b/packages/files-azure/tests/process.spec.ts
@@ -1,0 +1,5 @@
+describe('Files', () => {
+  it('should return ok', async () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/files-azure/tsconfig.json
+++ b/packages/files-azure/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "."
+  }
+}

--- a/packages/files-azure/tsup.config.ts
+++ b/packages/files-azure/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: false,
+  sourcemap: false,
+  dts: true,
+  clean: true,
+  minify: false,
+  format: ['cjs', 'esm']
+})

--- a/packages/files-gcs/CHANGELOG.md
+++ b/packages/files-gcs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/files-gcs/LICENSE
+++ b/packages/files-gcs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/files-gcs/README.md
+++ b/packages/files-gcs/README.md
@@ -1,0 +1,21 @@
+# Apoyo - Files (GCS Driver)
+
+[![npm version](https://badgen.net/npm/v/@apoyo/files-gcs)](https://www.npmjs.com/package/@apoyo/files-gcs)
+
+## Installation
+
+Install peer dependencies:
+`npm install @apoyo/files @apoyo/std`
+
+Install package:
+`npm install @apoyo/files-gcs`
+
+## Introduction
+
+This library is a standalone & framework agnostic version of [Adonisjs GCS Drive](https://github.com/adonisjs/drive-gcs).
+
+Please check out [@apoyo/files](https://github.com/neoxia/apoyo/tree/master/packages/files) for more information.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/files-gcs/jest.config.js
+++ b/packages/files-gcs/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/files-gcs/package.json
+++ b/packages/files-gcs/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@apoyo/files-gcs",
+  "version": "0.0.1",
+  "description": "File driver for GCS",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "tags": [
+    "utils",
+    "files",
+    "drive",
+    "gcs"
+  ],
+  "keywords": [
+    "utils",
+    "files",
+    "drive",
+    "gcs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-gcs",
+  "scripts": {
+    "test": "jest --verbose --runInBand",
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@apoyo/files": "0.0.1",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^14.18.21",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@apoyo/files": "0.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@google-cloud/storage": "^6.4.1"
+  }
+}

--- a/packages/files-gcs/package.json
+++ b/packages/files-gcs/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-gcs",
   "scripts": {
-    "test": "jest --verbose --runInBand",
+    "test": "jest --verbose --runInBand --passWithNoTests",
     "build": "tsup"
   },
   "devDependencies": {

--- a/packages/files-gcs/src/drivers/gcs.ts
+++ b/packages/files-gcs/src/drivers/gcs.ts
@@ -1,0 +1,260 @@
+import { pipeline } from 'stream'
+import { promisify } from 'util'
+
+import {
+  CannotCopyFileException,
+  CannotDeleteFileException,
+  CannotGetMetaDataException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  CannotWriteFileException,
+  ContentHeaders,
+  DriveFileStats,
+  DriverContract,
+  SignedUrlOptions,
+  WriteOptions
+} from '@apoyo/files'
+import { Bucket, GetSignedUrlConfig, Storage, StorageOptions } from '@google-cloud/storage'
+
+const pipelinePromise = promisify(pipeline)
+
+export type GcsDriverConfig = StorageOptions & {
+  bucket: string
+  usingUniformAcl?: boolean
+  cdnUrl?: string
+}
+
+export class GcsDriver implements DriverContract {
+  /**
+   * Reference to the GCS Bucket
+   */
+  private _gcsBucket: Bucket
+
+  /**
+   * Reference to the gcs storage instance
+   */
+  public adapter: Storage
+
+  /**
+   * Name of the driver
+   */
+  public name: 'gcs' = 'gcs'
+
+  constructor(private _config: GcsDriverConfig) {
+    this.adapter = new Storage(this._config)
+    this._gcsBucket = this.adapter.bucket(this._config.bucket)
+  }
+
+  /**
+   * Transforms the write options to GCS properties. Checkout the
+   * following example in the docs to see the available options
+   *
+   * https://googleapis.dev/nodejs/storage/latest/File.html#createWriteStream
+   */
+  private _transformWriteOptions(options?: WriteOptions) {
+    const { contentType, contentDisposition, contentEncoding, contentLanguage, ...adapterOptions } = Object.assign(
+      {},
+      options
+    )
+
+    adapterOptions.metadata = {}
+
+    if (contentType) {
+      adapterOptions['contentType'] = contentType
+    }
+
+    if (contentDisposition) {
+      adapterOptions.metadata['contentDisposition'] = contentDisposition
+    }
+
+    if (contentEncoding) {
+      adapterOptions.metadata['contentEncoding'] = contentEncoding
+    }
+
+    if (contentLanguage) {
+      adapterOptions.metadata['contentLanguage'] = contentLanguage
+    }
+
+    return adapterOptions
+  }
+
+  /**
+   * Transform content headers to GCS response headers
+   */
+  private _transformContentHeaders(options?: ContentHeaders) {
+    const contentHeaders: Partial<GetSignedUrlConfig> = {}
+    const { contentType, contentDisposition } = options || {}
+
+    if (contentType) {
+      contentHeaders['responseType'] = contentType
+    }
+    if (contentDisposition) {
+      contentHeaders['responseDisposition'] = contentDisposition
+    }
+
+    return contentHeaders
+  }
+
+  /**
+   * Converts seconds to milliseconds
+   */
+  private _secondsToTimeStamp(secs: number) {
+    return new Date(Date.now() + secs * 1000).getTime()
+  }
+
+  /**
+   * Returns a new instance of the GCS driver with
+   * a custom runtime bucket
+   */
+  public bucket(bucket: string): GcsDriver {
+    return new GcsDriver(Object.assign({}, this._config, { bucket }))
+  }
+
+  /**
+   * Returns the file contents as a buffer. The buffer return
+   * value allows you to self choose the encoding when
+   * converting the buffer to a string.
+   */
+  public async get(location: string): Promise<Buffer> {
+    try {
+      const [file] = await this._gcsBucket.file(location).download()
+      return file
+    } catch (error) {
+      throw new CannotReadFileException(location, error)
+    }
+  }
+
+  /**
+   * Returns the file contents as a stream
+   */
+  public async getStream(location: string): Promise<NodeJS.ReadableStream> {
+    return this._gcsBucket.file(location).createReadStream()
+  }
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  public async exists(location: string): Promise<boolean> {
+    try {
+      const [exists] = await this._gcsBucket.file(location).exists()
+      return exists
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'exists', error)
+    }
+  }
+
+  /**
+   * Returns the file stats
+   */
+  public async getStats(location: string): Promise<DriveFileStats> {
+    try {
+      const [metaData] = await this._gcsBucket.file(location).getMetadata()
+
+      return {
+        modified: new Date(metaData.updated),
+        size: metaData.size!,
+        isFile: true,
+        etag: metaData.etag
+      }
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'stats', error)
+    }
+  }
+
+  /**
+   * Returns the signed url for a given path
+   */
+  public async getSignedUrl(location: string, options?: SignedUrlOptions): Promise<string> {
+    try {
+      const sixDays = 6 * 24 * 60 * 60
+      const [url] = await this._gcsBucket.file(location).getSignedUrl({
+        action: 'read',
+        /**
+         * Using v2 doesn't allow overriding content-type header
+         */
+        version: 'v4',
+        expires: this._secondsToTimeStamp(options?.expiresIn || sixDays),
+        ...this._transformContentHeaders(options)
+      })
+      return url
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'signedUrl', error)
+    }
+  }
+
+  /**
+   * Returns URL to a given path
+   */
+  public async getUrl(location: string): Promise<string> {
+    return this._gcsBucket.file(location).publicUrl()
+  }
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   */
+  public async put(location: string, contents: Buffer | string, options?: WriteOptions): Promise<void> {
+    try {
+      await this._gcsBucket.file(location).save(contents, {
+        resumable: false,
+        ...this._transformWriteOptions(options)
+      })
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  public async putStream(location: string, contents: NodeJS.ReadableStream, options?: WriteOptions): Promise<void> {
+    try {
+      const destination = this._gcsBucket.file(location).createWriteStream({
+        resumable: false,
+        ...this._transformWriteOptions(options)
+      })
+      await pipelinePromise(contents, destination)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Remove a given location path
+   */
+  public async delete(location: string): Promise<void> {
+    try {
+      await this._gcsBucket.file(location).delete({ ignoreNotFound: true })
+    } catch (error) {
+      throw new CannotDeleteFileException(location, error)
+    }
+  }
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async copy(source: string, destination: string, options?: WriteOptions): Promise<void> {
+    options = options || {}
+
+    try {
+      await this._gcsBucket.file(source).copy(destination, this._transformWriteOptions(options))
+    } catch (error) {
+      throw new CannotCopyFileException(source, destination, error.original || error)
+    }
+  }
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async move(source: string, destination: string, options?: WriteOptions): Promise<void> {
+    try {
+      await this.copy(source, destination, options)
+      await this.delete(source)
+    } catch (error) {
+      throw new CannotMoveFileException(source, destination, error.original || error)
+    }
+  }
+}

--- a/packages/files-gcs/src/index.ts
+++ b/packages/files-gcs/src/index.ts
@@ -1,0 +1,1 @@
+export { GcsDriver, GcsDriverConfig } from './drivers/gcs'

--- a/packages/files-gcs/tests/process.spec.ts
+++ b/packages/files-gcs/tests/process.spec.ts
@@ -1,5 +1,0 @@
-describe('Files', () => {
-  it('should return ok', async () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/files-gcs/tests/process.spec.ts
+++ b/packages/files-gcs/tests/process.spec.ts
@@ -1,0 +1,5 @@
+describe('Files', () => {
+  it('should return ok', async () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/files-gcs/tsconfig.json
+++ b/packages/files-gcs/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "."
+  }
+}

--- a/packages/files-gcs/tsup.config.ts
+++ b/packages/files-gcs/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: false,
+  sourcemap: false,
+  dts: true,
+  clean: true,
+  minify: false,
+  format: ['cjs', 'esm']
+})

--- a/packages/files-s3/CHANGELOG.md
+++ b/packages/files-s3/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/files-s3/LICENSE
+++ b/packages/files-s3/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/files-s3/README.md
+++ b/packages/files-s3/README.md
@@ -1,0 +1,21 @@
+# Apoyo - Files (S3 Driver)
+
+[![npm version](https://badgen.net/npm/v/@apoyo/files-s3)](https://www.npmjs.com/package/@apoyo/files-s3)
+
+## Installation
+
+Install peer dependencies:
+`npm install @apoyo/files @apoyo/std`
+
+Install package:
+`npm install @apoyo/files-s3`
+
+## Introduction
+
+This library is a standalone & framework agnostic version of [Adonisjs S3 Drive](https://github.com/adonisjs/drive-s3).
+
+Please check out [@apoyo/files](https://github.com/neoxia/apoyo/tree/master/packages/files) for more information.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/files-s3/README.md
+++ b/packages/files-s3/README.md
@@ -12,7 +12,7 @@ Install package:
 
 ## Introduction
 
-This library is a standalone & framework agnostic version of [Adonisjs S3 Drive](https://github.com/adonisjs/drive-s3).
+This library is a simplified framework agnostic version of [Adonisjs S3 Drive](https://github.com/adonisjs/drive-s3).
 
 Please check out [@apoyo/files](https://github.com/neoxia/apoyo/tree/master/packages/files) for more information.
 

--- a/packages/files-s3/jest.config.js
+++ b/packages/files-s3/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/files-s3/package.json
+++ b/packages/files-s3/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@apoyo/files-s3",
+  "version": "0.0.1",
+  "description": "File driver for S3",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "tags": [
+    "utils",
+    "files",
+    "drive",
+    "s3"
+  ],
+  "keywords": [
+    "utils",
+    "files",
+    "drive",
+    "s3"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-s3",
+  "scripts": {
+    "test": "jest --verbose --runInBand",
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@apoyo/files": "0.0.1",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^14.18.21",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@apoyo/files": "0.0.1"
+  },
+  "dependencies": {
+    "@aws-sdk/client-s3": "^3.161.0",
+    "@aws-sdk/lib-storage": "^3.161.0",
+    "@aws-sdk/s3-request-presigner": "^3.161.0",
+    "get-stream": "^6.0.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/files-s3/package.json
+++ b/packages/files-s3/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files-s3",
   "scripts": {
-    "test": "jest --verbose --runInBand",
+    "test": "jest --verbose --runInBand --passWithNoTests",
     "build": "tsup"
   },
   "devDependencies": {

--- a/packages/files-s3/src/drivers/s3.ts
+++ b/packages/files-s3/src/drivers/s3.ts
@@ -1,0 +1,374 @@
+import getStream from 'get-stream'
+import { format } from 'url'
+
+import {
+  CannotCopyFileException,
+  CannotDeleteFileException,
+  CannotGetMetaDataException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  CannotWriteFileException,
+  ContentHeaders,
+  DriveFileStats,
+  DriverContract,
+  SignedUrlOptions,
+  WriteOptions
+} from '@apoyo/files'
+import {
+  CopyObjectCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  GetObjectCommandInput,
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+  S3ClientConfig,
+  Tag
+} from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+export type S3DriverConfig = S3ClientConfig & {
+  bucket: string
+  cdnUrl?: string
+  key?: string
+  secret?: string
+}
+
+/**
+ * An implementation of the s3 driver for AdonisJS drive
+ */
+export class S3Driver implements DriverContract {
+  /**
+   * Reference to the s3 client
+   */
+  public adapter: S3Client
+
+  /**
+   * Name of the driver
+   */
+  public name: 's3' = 's3'
+
+  constructor(private _config: S3DriverConfig) {
+    /**
+     * Use the top level key and secret to define AWS credentials
+     */
+    if (this._config.key && this._config.secret) {
+      this._config.credentials = {
+        accessKeyId: this._config.key,
+        secretAccessKey: this._config.secret
+      }
+    }
+
+    this.adapter = new S3Client(this._config)
+  }
+
+  /**
+   * Transforms the write options to S3 properties
+   */
+  private _transformWriteOptions(options?: WriteOptions) {
+    const {
+      contentType,
+      contentDisposition,
+      contentEncoding,
+      contentLanguage,
+      cacheControl,
+      ...adapterOptions
+    } = Object.assign({}, options)
+
+    if (contentType) {
+      adapterOptions['ContentType'] = contentType
+    }
+
+    if (contentDisposition) {
+      adapterOptions['ContentDisposition'] = contentDisposition
+    }
+
+    if (contentEncoding) {
+      adapterOptions['ContentEncoding'] = contentEncoding
+    }
+
+    if (contentLanguage) {
+      adapterOptions['ContentLanguage'] = contentLanguage
+    }
+
+    if (cacheControl) {
+      adapterOptions['CacheControl'] = cacheControl
+    }
+
+    return adapterOptions
+  }
+
+  /**
+   * Transform content headers to S3 response content type
+   */
+  private _transformContentHeaders(options?: ContentHeaders) {
+    const contentHeaders: Omit<GetObjectCommandInput, 'Key' | 'Bucket'> = {}
+    const { contentType, contentDisposition, contentEncoding, contentLanguage, cacheControl } = options || {}
+
+    if (contentType) {
+      contentHeaders['ResponseContentType'] = contentType
+    }
+
+    if (contentDisposition) {
+      contentHeaders['ResponseContentDisposition'] = contentDisposition
+    }
+
+    if (contentEncoding) {
+      contentHeaders['ResponseContentEncoding'] = contentEncoding
+    }
+
+    if (contentLanguage) {
+      contentHeaders['ResponseContentLanguage'] = contentLanguage
+    }
+
+    if (cacheControl) {
+      contentHeaders['ResponseCacheControl'] = cacheControl
+    }
+
+    return contentHeaders
+  }
+
+  /**
+   * Returns a new instance of the s3 driver with a custom runtime
+   * bucket
+   */
+  public bucket(bucket: string): S3Driver {
+    return new S3Driver(Object.assign({}, this._config, { bucket }))
+  }
+
+  /**
+   * Returns the file contents as a buffer. The buffer return
+   * value allows you to self choose the encoding when
+   * converting the buffer to a string.
+   */
+  public async get(location: string): Promise<Buffer> {
+    return getStream.buffer(await this.getStream(location))
+  }
+
+  /**
+   * Returns the file contents as a stream
+   */
+  public async getStream(location: string): Promise<NodeJS.ReadableStream> {
+    try {
+      const response = await this.adapter.send(new GetObjectCommand({ Key: location, Bucket: this._config.bucket }))
+
+      return response.Body
+    } catch (error) {
+      throw new CannotReadFileException(location, error)
+    }
+  }
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  public async exists(location: string): Promise<boolean> {
+    try {
+      await this.adapter.send(
+        new HeadObjectCommand({
+          Key: location,
+          Bucket: this._config.bucket
+        })
+      )
+
+      return true
+    } catch (error) {
+      if (error.$metadata?.httpStatusCode === 404) {
+        return false
+      }
+
+      throw new CannotGetMetaDataException(location, 'exists', error)
+    }
+  }
+
+  /**
+   * Returns the file stats
+   */
+  public async getStats(location: string): Promise<DriveFileStats> {
+    try {
+      const stats = await this.adapter.send(
+        new HeadObjectCommand({
+          Key: location,
+          Bucket: this._config.bucket
+        })
+      )
+
+      return {
+        modified: stats.LastModified!,
+        size: stats.ContentLength!,
+        isFile: true,
+        etag: stats.ETag
+      }
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'stats', error)
+    }
+  }
+
+  /**
+   * Returns the signed url for a given path
+   */
+  public async getSignedUrl(location: string, options?: SignedUrlOptions): Promise<string> {
+    try {
+      return await getSignedUrl(
+        this.adapter,
+        new GetObjectCommand({
+          Key: location,
+          Bucket: this._config.bucket,
+          ...this._transformContentHeaders(options)
+        }),
+        {
+          expiresIn: options?.expiresIn ?? 15 * 60
+        }
+      )
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'signedUrl', error)
+    }
+  }
+
+  /**
+   * Returns URL to a given path
+   */
+  public async getUrl(location: string): Promise<string> {
+    /**
+     * Use the CDN URL if defined
+     */
+    if (this._config.cdnUrl) {
+      return `${this._config.cdnUrl}/${location}`
+    }
+
+    const href = format(await this.adapter.config.endpoint())
+    if (href.startsWith('https://s3.amazonaws')) {
+      return `https://${this._config.bucket}.s3.amazonaws.com/${location}`
+    }
+
+    return `${href}/${this._config.bucket}/${location}`
+  }
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   */
+  public async put(location: string, contents: Buffer | string, options?: WriteOptions): Promise<void> {
+    try {
+      await this.adapter.send(
+        new PutObjectCommand({
+          Key: location,
+          Body: contents,
+          Bucket: this._config.bucket,
+          ...this._transformWriteOptions(options)
+        })
+      )
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  public async putStream(
+    location: string,
+    contents: NodeJS.ReadableStream,
+    options?: WriteOptions & {
+      multipart?: boolean
+      queueSize?: number
+      partSize?: number
+      leavePartsOnError?: boolean
+      tags?: Tag[]
+      tap?: (stream: Upload) => void
+    }
+  ): Promise<void> {
+    try {
+      options = Object.assign({}, options)
+
+      /**
+       * Upload as multipart stream
+       */
+      if (options.multipart) {
+        const { tap, queueSize, partSize, leavePartsOnError, tags, ...others } = options
+        const upload = new Upload({
+          params: {
+            Key: location,
+            Body: contents,
+            Bucket: this._config.bucket,
+            ...this._transformWriteOptions(others)
+          },
+          queueSize,
+          partSize,
+          leavePartsOnError,
+          tags,
+          client: this.adapter
+        })
+
+        if (typeof tap === 'function') {
+          tap(upload)
+        }
+
+        await upload.done()
+        return
+      }
+
+      await this.adapter.send(
+        new PutObjectCommand({
+          Key: location,
+          Body: contents,
+          Bucket: this._config.bucket,
+          ...this._transformWriteOptions(options)
+        })
+      )
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Remove a given location path
+   */
+  public async delete(location: string): Promise<void> {
+    try {
+      await this.adapter.send(
+        new DeleteObjectCommand({
+          Key: location,
+          Bucket: this._config.bucket
+        })
+      )
+    } catch (error) {
+      throw new CannotDeleteFileException(location, error)
+    }
+  }
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async copy(source: string, destination: string, options?: WriteOptions): Promise<void> {
+    options = options || {}
+
+    try {
+      await this.adapter.send(
+        new CopyObjectCommand({
+          Key: destination,
+          CopySource: `/${this._config.bucket}/${source}`,
+          Bucket: this._config.bucket,
+          ...this._transformWriteOptions(options)
+        })
+      )
+    } catch (error) {
+      throw new CannotCopyFileException(source, destination, error.original || error)
+    }
+  }
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async move(source: string, destination: string, options?: WriteOptions): Promise<void> {
+    try {
+      await this.copy(source, destination, options)
+      await this.delete(source)
+    } catch (error) {
+      throw new CannotMoveFileException(source, destination, error.original || error)
+    }
+  }
+}

--- a/packages/files-s3/src/index.ts
+++ b/packages/files-s3/src/index.ts
@@ -1,0 +1,1 @@
+export { S3Driver, S3DriverConfig } from './drivers/s3'

--- a/packages/files-s3/tests/process.spec.ts
+++ b/packages/files-s3/tests/process.spec.ts
@@ -1,5 +1,0 @@
-describe('Files', () => {
-  it('should return ok', async () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/files-s3/tests/process.spec.ts
+++ b/packages/files-s3/tests/process.spec.ts
@@ -1,0 +1,5 @@
+describe('Files', () => {
+  it('should return ok', async () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/files-s3/tsconfig.json
+++ b/packages/files-s3/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "."
+  }
+}

--- a/packages/files-s3/tsup.config.ts
+++ b/packages/files-s3/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: false,
+  sourcemap: false,
+  dts: true,
+  clean: true,
+  minify: false,
+  format: ['cjs', 'esm']
+})

--- a/packages/files/CHANGELOG.md
+++ b/packages/files/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/files/LICENSE
+++ b/packages/files/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -14,17 +14,21 @@ Install package:
 
 This library is a simplified framework agnostic version of [Adonisjs Drive](https://github.com/adonisjs/drive).
 
-As such, it will provide the users of this library a multitude of pre-made file drivers for existing file providers:
+The following file drivers are provided by default:
 
-- Local file driver
-- Memory driver
-- AWS S3 driver
+- Local file driver (included in `@apoyo/files`)
+- Memory / Fake driver (included in `@apoyo/files`)
+- AWS S3 driver (included in `@apoyo/files-s3`)
+- GCS driver (included in `@apoyo/files-gcs`)
+- Azure storage driver (included in `@apoyo/files-azure`)
 
-Other providers may be added if required. Please create a Github issue in that case.
+Custom providers can also be created by implementing the `DriverContract` interface available in `@apoyo/files`.
 
 ## Documentation
 
 TODO
+
+Look up the [DriverContract](https://github.com/neoxia/apoyo/tree/master/packages/files/src/driver.ts) interface until the documentation has been written.
 
 ## License
 

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -1,0 +1,31 @@
+# Apoyo - Files
+
+[![npm version](https://badgen.net/npm/v/@apoyo/files)](https://www.npmjs.com/package/@apoyo/files)
+
+## Installation
+
+Install peer dependencies:
+`npm install @apoyo/std`
+
+Install package:
+`npm install @apoyo/files`
+
+## Introduction
+
+This library is a simplified framework agnostic version of [Adonisjs Drive](https://github.com/adonisjs/drive).
+
+As such, it will provide the users of this library a multitude of pre-made file drivers for existing file providers:
+
+- Local file driver
+- Memory driver
+- AWS S3 driver
+
+Other providers may be added if required. Please create a Github issue in that case.
+
+## Documentation
+
+TODO
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/files/jest.config.js
+++ b/packages/files/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@apoyo/files",
+  "version": "0.0.1",
+  "description": "Utils focused around files management",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "engines": {
+    "node": ">= 14.0.0"
+  },
+  "tags": [
+    "utils",
+    "files",
+    "drive"
+  ],
+  "keywords": [
+    "utils",
+    "files",
+    "drive"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files",
+  "scripts": {
+    "test": "jest --verbose --runInBand",
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@apoyo/std": "0.0.15",
+    "@types/etag": "^1.8.1",
+    "@types/fs-extra": "^9.0.13",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^14.18.21",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "etag": "^1.8.1",
+    "fs-extra": "^10.1.0",
+    "memfs": "^3.4.7"
+  },
+  "peerDependencies": {
+    "@apoyo/std": "0.0.15"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/files",
   "scripts": {
-    "test": "jest --verbose --runInBand",
+    "test": "jest --verbose --runInBand --passWithNoTests",
     "build": "tsup"
   },
   "devDependencies": {
@@ -42,7 +42,9 @@
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.18.21",
+    "@types/rimraf": "^3",
     "jest": "^26.4.2",
+    "rimraf": "^3.0.2",
     "ts-jest": "^26.3.0",
     "ts-node": "^8.0.2",
     "tsup": "^6.1.2",

--- a/packages/files/src/driver.ts
+++ b/packages/files/src/driver.ts
@@ -1,0 +1,104 @@
+/**
+ * Content options for files
+ */
+export type ContentHeaders = {
+  contentType?: string
+  contentLanguage?: string
+  contentEncoding?: string
+  contentDisposition?: string
+  cacheControl?: string
+}
+
+/**
+ * Options for writing, moving and copying files
+ */
+export type WriteOptions = ContentHeaders & Record<string, any>
+
+/**
+ * Options for generating signed urls
+ */
+export type SignedUrlOptions = ContentHeaders & {
+  /**
+   * Signed URL expiration time in seconds
+   */
+  expiresIn?: number
+}
+
+/**
+ * Stats returned by the drive drivers
+ */
+export type DriveFileStats = {
+  size: number
+  modified: Date
+  isFile: boolean
+  etag?: string
+}
+
+/**
+ * Shape of the generic driver
+ */
+export interface DriverContract {
+  /**
+   * Name of the driver
+   */
+  name: string
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  exists(location: string): Promise<boolean>
+
+  /**
+   * Returns the file contents as a buffer.
+   */
+  get(location: string): Promise<Buffer>
+
+  /**
+   * Returns the file contents as a stream
+   */
+  getStream(location: string): Promise<NodeJS.ReadableStream>
+
+  /**
+   * Returns the location path stats
+   */
+  getStats(location: string): Promise<DriveFileStats>
+
+  /**
+   * Returns a signed URL for a given location path
+   */
+  getSignedUrl(location: string, options?: SignedUrlOptions): Promise<string>
+
+  /**
+   * Returns a URL for a given location path
+   */
+  getUrl(location: string): Promise<string>
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   */
+  put(location: string, contents: Buffer | string, options?: WriteOptions): Promise<void>
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  putStream(location: string, contents: NodeJS.ReadableStream, options?: WriteOptions): Promise<void>
+
+  /**
+   * Remove a given location path
+   */
+  delete(location: string): Promise<void>
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  copy(source: string, destination: string, options?: WriteOptions): Promise<void>
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  move(source: string, destination: string, options?: WriteOptions): Promise<void>
+}

--- a/packages/files/src/drivers/fake.ts
+++ b/packages/files/src/drivers/fake.ts
@@ -1,0 +1,247 @@
+import etag from 'etag'
+import { Volume } from 'memfs'
+import { dirname } from 'path'
+
+import { DriveFileStats, DriverContract, SignedUrlOptions } from '../driver'
+
+import { pipelinePromise } from '../utils'
+
+import {
+  CannotCopyFileException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  CannotWriteFileException,
+  CannotDeleteFileException,
+  CannotGetMetaDataException,
+  CannotGenerateUrlException
+} from '../exceptions'
+
+export interface FakeDriverConfig {
+  /**
+   * Configure how `getUrl` and `getSignedUrl` computes the URL for a given file
+   */
+  serveFiles?: {
+    makeUrl(location: string): string
+    makeSignedUrl(location: string, options?: SignedUrlOptions): string
+  }
+}
+
+/**
+ * Memory driver is mainly used for testing
+ */
+export class FakeDriver implements DriverContract {
+  /**
+   * Reference to the underlying adapter. Which is memfs
+   */
+  public adapter = new Volume()
+
+  /**
+   * Name of the driver
+   */
+  public name: 'fake' = 'fake'
+
+  constructor(private _config: FakeDriverConfig) {}
+
+  /**
+   * Make absolute path to a given location
+   */
+  public makePath(location: string) {
+    return location
+  }
+
+  /**
+   * Creates the directory recursively with in the memory
+   */
+  private _ensureDir(location: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.adapter.mkdirp(dirname(location), (error: Error) => {
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * Returns the file contents as a buffer. The buffer return
+   * value allows you to self choose the encoding when
+   * converting the buffer to a string.
+   */
+  public async get(location: string): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      this.adapter.readFile(this.makePath(location), (error: Error, data: Buffer) => {
+        if (error) {
+          reject(new CannotReadFileException(location, error))
+        } else {
+          resolve(data)
+        }
+      })
+    })
+  }
+
+  /**
+   * Returns the file contents as a stream
+   */
+  public async getStream(location: string): Promise<NodeJS.ReadableStream> {
+    return this.adapter.createReadStream(this.makePath(location))
+  }
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  public exists(location: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.adapter.exists(this.makePath(location), (exists: boolean) => {
+        resolve(exists)
+      })
+    })
+  }
+
+  /**
+   * Returns the file stats
+   */
+  public async getStats(location: string): Promise<DriveFileStats> {
+    return new Promise((resolve, reject) => {
+      this.adapter.stat(this.makePath(location), (error, stats) => {
+        if (error) {
+          reject(new CannotGetMetaDataException(location, 'stats', error))
+        } else {
+          resolve({
+            modified: stats!.mtime,
+            size: stats!.size as number,
+            isFile: stats!.isFile(),
+            etag: etag(stats as etag.StatsLike)
+          })
+        }
+      })
+    })
+  }
+
+  /**
+   * Returns a signed URL for a given location path
+   */
+  public async getSignedUrl(location: string, options?: SignedUrlOptions): Promise<string> {
+    if (!this._config.serveFiles) {
+      throw new CannotGenerateUrlException(location)
+    }
+    return this._config.serveFiles.makeSignedUrl(location, options)
+  }
+
+  /**
+   * Returns a URL for a given location path
+   */
+  public async getUrl(location: string): Promise<string> {
+    if (!this._config.serveFiles) {
+      throw new CannotGenerateUrlException(location)
+    }
+    return this._config.serveFiles.makeUrl(location)
+  }
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   */
+  public async put(location: string, contents: Buffer | string): Promise<void> {
+    const absolutePath = this.makePath(location)
+    await this._ensureDir(absolutePath)
+
+    return new Promise((resolve, reject) => {
+      this.adapter.writeFile(absolutePath, contents, (error) => {
+        if (error) {
+          reject(new CannotWriteFileException(location, error))
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  public async putStream(location: string, contents: NodeJS.ReadableStream): Promise<void> {
+    const absolutePath = this.makePath(location)
+    try {
+      await this._ensureDir(absolutePath)
+
+      const writeStream = this.adapter.createWriteStream(absolutePath)
+
+      /**
+       * If streaming is interrupted, then the destination file will be
+       * created with partial or empty contents.
+       *
+       * Earlier we are cleaning up the empty file, which addresses one
+       * use case (no pre-existing file was there).
+       *
+       * However, in case there was already a file, it will be then emptied
+       * out. So basically there is no way to get the original contents
+       * back unless we read the existing content in buffer, but then
+       * we don't know how large the file is.
+       */
+      await pipelinePromise(contents, writeStream)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Remove a given location path
+   */
+  public async delete(location: string): Promise<void> {
+    if (!(await this.exists(location))) {
+      return
+    }
+
+    return new Promise((resolve, reject) => {
+      this.adapter.unlink(this.makePath(location), (error) => {
+        if (error) {
+          reject(new CannotDeleteFileException(location, error))
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async copy(source: string, destination: string): Promise<void> {
+    const desintationAbsolutePath = this.makePath(destination)
+    await this._ensureDir(desintationAbsolutePath)
+
+    return new Promise((resolve, reject) => {
+      this.adapter.copyFile(this.makePath(source), desintationAbsolutePath, (error) => {
+        if (error) {
+          reject(new CannotCopyFileException(source, destination, error))
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async move(source: string, destination: string): Promise<void> {
+    const sourceAbsolutePath = this.makePath(source)
+    const desintationAbsolutePath = this.makePath(destination)
+    await this._ensureDir(desintationAbsolutePath)
+
+    return new Promise<void>((resolve, reject) => {
+      this.adapter.copyFile(sourceAbsolutePath, desintationAbsolutePath, (error) => {
+        if (error) {
+          reject(new CannotMoveFileException(source, destination, error))
+        } else {
+          resolve()
+        }
+      })
+    }).then(() => this.delete(source))
+  }
+}

--- a/packages/files/src/drivers/local.ts
+++ b/packages/files/src/drivers/local.ts
@@ -1,0 +1,211 @@
+import etag from 'etag'
+import * as fsExtra from 'fs-extra'
+import path, { dirname } from 'path'
+
+import { DriveFileStats, DriverContract, SignedUrlOptions } from '../driver'
+
+import { pipelinePromise } from '../utils'
+
+import {
+  CannotCopyFileException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  CannotWriteFileException,
+  CannotGenerateUrlException,
+  CannotDeleteFileException,
+  CannotGetMetaDataException
+} from '../exceptions'
+
+export interface LocalDriverConfig {
+  /**
+   * Root directory in which to search for your files on your local filesystem
+   */
+  root: string
+
+  /**
+   * Configure how `getUrl` and `getSignedUrl` computes the URL for a given file
+   */
+  serveFiles?: {
+    makeUrl(location: string): string
+    makeSignedUrl(location: string, options?: SignedUrlOptions): string
+  }
+}
+
+/**
+ * Local driver interacts with the local file system
+ */
+export class LocalDriver implements DriverContract {
+  /**
+   * Reference to the underlying adapter. Which is
+   * fs-extra
+   */
+  public adapter = fsExtra
+
+  /**
+   * Name of the driver
+   */
+  public name: 'local' = 'local'
+
+  constructor(private _config: LocalDriverConfig) {}
+
+  /**
+   * Make absolute path to a given location
+   */
+  public makePath(location: string) {
+    return path.join(this._config.root, location)
+  }
+
+  /**
+   * Returns the file contents as a buffer. The buffer return
+   * value allows you to self choose the encoding when
+   * converting the buffer to a string.
+   */
+  public async get(location: string): Promise<Buffer> {
+    try {
+      return await this.adapter.readFile(this.makePath(location))
+    } catch (error) {
+      throw new CannotReadFileException(location, error)
+    }
+  }
+
+  /**
+   * Returns the file contents as a stream
+   */
+  public async getStream(location: string): Promise<NodeJS.ReadableStream> {
+    try {
+      return this.adapter.createReadStream(this.makePath(location))
+    } catch (error) {
+      throw new CannotReadFileException(location, error)
+    }
+  }
+
+  /**
+   * A boolean to find if the location path exists or not
+   */
+  public async exists(location: string): Promise<boolean> {
+    try {
+      return await this.adapter.pathExists(this.makePath(location))
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'exists', error)
+    }
+  }
+
+  /**
+   * Returns the file stats
+   */
+  public async getStats(location: string): Promise<DriveFileStats> {
+    try {
+      const stats = await this.adapter.stat(this.makePath(location))
+      return {
+        modified: stats.mtime,
+        size: stats.size,
+        isFile: stats.isFile(),
+        etag: etag(stats)
+      }
+    } catch (error) {
+      throw new CannotGetMetaDataException(location, 'stats', error)
+    }
+  }
+
+  /**
+   * Returns a signed URL for a given location path
+   */
+  public async getSignedUrl(location: string, options?: SignedUrlOptions): Promise<string> {
+    if (!this._config.serveFiles) {
+      throw new CannotGenerateUrlException(location)
+    }
+    return this._config.serveFiles.makeSignedUrl(location, options)
+  }
+
+  /**
+   * Returns a URL for a given location path
+   */
+  public async getUrl(location: string): Promise<string> {
+    if (!this._config.serveFiles) {
+      throw new CannotGenerateUrlException(location)
+    }
+    return this._config.serveFiles.makeUrl(location)
+  }
+
+  /**
+   * Write string|buffer contents to a destination. The missing
+   * intermediate directories will be created (if required).
+   */
+  public async put(location: string, contents: Buffer | string): Promise<void> {
+    try {
+      await this.adapter.outputFile(this.makePath(location), contents)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Write a stream to a destination. The missing intermediate
+   * directories will be created (if required).
+   */
+  public async putStream(location: string, contents: NodeJS.ReadableStream): Promise<void> {
+    const absolutePath = this.makePath(location)
+
+    const dir = dirname(absolutePath)
+    await this.adapter.ensureDir(dir)
+
+    const writeStream = this.adapter.createWriteStream(absolutePath)
+
+    /**
+     * If streaming is interrupted, then the destination file will be
+     * created with partial or empty contents.
+     *
+     * Earlier we are cleaning up the empty file, which addresses one
+     * use case (no pre-existing file was there).
+     *
+     * However, in case there was already a file, it will be then emptied
+     * out. So basically there is no way to get the original contents
+     * back unless we read the existing content in buffer, but then
+     * we don't know how large the file is.
+     */
+    try {
+      await pipelinePromise(contents, writeStream)
+    } catch (error) {
+      throw new CannotWriteFileException(location, error)
+    }
+  }
+
+  /**
+   * Remove a given location path
+   */
+  public async delete(location: string): Promise<void> {
+    try {
+      await this.adapter.remove(this.makePath(location))
+    } catch (error) {
+      throw new CannotDeleteFileException(location, error)
+    }
+  }
+
+  /**
+   * Copy a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async copy(source: string, destination: string): Promise<void> {
+    try {
+      await this.adapter.copy(this.makePath(source), this.makePath(destination), {
+        overwrite: true
+      })
+    } catch (error) {
+      throw new CannotCopyFileException(source, destination, error)
+    }
+  }
+
+  /**
+   * Move a given location path from the source to the desination.
+   * The missing intermediate directories will be created (if required)
+   */
+  public async move(source: string, destination: string): Promise<void> {
+    try {
+      await this.adapter.move(this.makePath(source), this.makePath(destination), {
+        overwrite: true
+      })
+    } catch (error) {
+      throw new CannotMoveFileException(source, destination, error)
+    }
+  }
+}

--- a/packages/files/src/drivers/local.ts
+++ b/packages/files/src/drivers/local.ts
@@ -97,7 +97,7 @@ export class LocalDriver implements DriverContract {
     try {
       const stats = await this.adapter.stat(this.makePath(location))
       return {
-        modified: stats.mtime,
+        modified: new Date(stats.mtime),
         size: stats.size,
         isFile: stats.isFile(),
         etag: etag(stats)

--- a/packages/files/src/exceptions.ts
+++ b/packages/files/src/exceptions.ts
@@ -1,0 +1,73 @@
+import { Exception } from '@apoyo/std'
+
+/**
+ * Base exception class for file errors
+ */
+export class FileException extends Exception {
+  constructor(message: string, cause: Error | undefined, public readonly code: string) {
+    super(message, cause)
+  }
+}
+
+/**
+ * Unable to write file to the destination
+ */
+export class CannotWriteFileException extends FileException {
+  constructor(public readonly location: string, cause: Error) {
+    super(`Cannot write file at location "${location}"`, cause, 'E_CANNOT_WRITE_FILE')
+  }
+}
+
+/**
+ * Unable to read file from a given location
+ */
+export class CannotReadFileException extends FileException {
+  constructor(public readonly location: string, cause: Error) {
+    super(`Cannot read file from location "${location}"`, cause, 'E_CANNOT_READ_FILE')
+  }
+}
+
+/**
+ * Unable to delete file from a given location
+ */
+export class CannotDeleteFileException extends FileException {
+  constructor(public readonly location: string, cause: Error) {
+    super(`Cannot delete file at location "${location}"`, cause, 'E_CANNOT_DELETE_FILE')
+  }
+}
+
+/**
+ * Unable to copy file from source to destination
+ */
+export class CannotCopyFileException extends FileException {
+  constructor(public readonly source: string, public readonly destination: string, cause: Error) {
+    super(`Cannot copy file from "${source}" to "${destination}"`, cause, 'E_CANNOT_COPY_FILE')
+  }
+}
+
+/**
+ * Unable to move file from source to destination
+ */
+export class CannotMoveFileException extends FileException {
+  constructor(public readonly source: string, public readonly destination: string, cause: Error) {
+    super(`Cannot move file from "${source}" to "${destination}"`, cause, 'E_CANNOT_MOVE_FILE')
+  }
+}
+
+/**
+ * Unable to get file metadata
+ */
+export class CannotGetMetaDataException extends FileException {
+  constructor(public readonly location: string, public readonly operation: string, cause: Error) {
+    super(`Unable to retrieve the "${operation}" for file at location "${location}"`, cause, 'E_CANNOT_GET_METADATA')
+  }
+}
+
+/**
+ * Unable to generate url for a file. The assets serving is disabled
+ */
+export class CannotGenerateUrlException extends FileException {
+  constructor(public readonly location: string) {
+    super(`Cannot generate URL for location "${location}".`, undefined, 'E_CANNOT_GENERATE_URL')
+  }
+}

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -1,0 +1,4 @@
+export * from './driver'
+export * from './exceptions'
+export { LocalDriver, LocalDriverConfig } from './drivers/local'
+export { FakeDriver, FakeDriverConfig } from './drivers/fake'

--- a/packages/files/src/utils.ts
+++ b/packages/files/src/utils.ts
@@ -1,0 +1,4 @@
+import { promisify } from 'util'
+import { pipeline } from 'stream'
+
+export const pipelinePromise = promisify(pipeline)

--- a/packages/files/tests/drivers/fake.spec.ts
+++ b/packages/files/tests/drivers/fake.spec.ts
@@ -1,7 +1,5 @@
-import { tmpdir } from 'os'
 import path from 'path'
 import { Readable } from 'stream'
-import rimraf from 'rimraf'
 
 import { pipe, Str } from '@apoyo/std'
 
@@ -11,24 +9,14 @@ import {
   CannotMoveFileException,
   CannotReadFileException,
   FileException,
-  LocalDriver,
-  LocalDriverConfig
+  FakeDriver,
+  FakeDriverConfig
 } from '../../src'
 
-const TEST_ROOT = path.resolve(tmpdir(), 'tests')
-
-const cleanup = async () => {
-  return new Promise<void>((resolve, reject) => rimraf(TEST_ROOT, {}, (err) => (err ? reject(err) : resolve())))
-}
-
 describe('Local driver | put', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('write file to the destination', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
 
@@ -38,8 +26,8 @@ describe('Local driver | put', () => {
   })
 
   it('create intermediate directories when missing', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('bar/baz/foo.txt', 'hello world')
 
@@ -49,8 +37,8 @@ describe('Local driver | put', () => {
   })
 
   it('overwrite destination when file already exists', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hi world')
     await driver.put('foo.txt', 'hello world')
@@ -62,13 +50,9 @@ describe('Local driver | put', () => {
 })
 
 describe('Local driver | putStream', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('write stream to a file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     const stream = new Readable({
       read() {
@@ -86,8 +70,8 @@ describe('Local driver | putStream', () => {
   })
 
   it('create intermediate directories when writing a stream to a file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     const stream = new Readable({
       read() {
@@ -105,8 +89,8 @@ describe('Local driver | putStream', () => {
   })
 
   it('overwrite existing file when stream to a file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     const stream = new Readable({
       read() {
@@ -126,41 +110,33 @@ describe('Local driver | putStream', () => {
 })
 
 describe('Local driver | exists', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('return true when a file exists', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('bar/baz/foo.txt', 'bar')
     expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
   })
 
   it("return false when a file doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     expect(await driver.exists('foo.txt')).toBe(false)
   })
 
   it("return false when a file parent directory doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
   })
 })
 
 describe('Local driver | delete', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('remove file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('bar/baz/foo.txt', 'bar')
     await driver.delete('bar/baz/foo.txt')
@@ -169,16 +145,16 @@ describe('Local driver | delete', () => {
   })
 
   it('do not error when trying to remove a non-existing file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.delete('foo.txt')
     expect(await driver.exists('foo.txt')).toBe(false)
   })
 
   it("do not error when file parent directory doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.delete('bar/baz/foo.txt')
     expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
@@ -186,13 +162,9 @@ describe('Local driver | delete', () => {
 })
 
 describe('Local driver | copy', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('copy file from within the disk root', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.copy('foo.txt', 'bar.txt')
@@ -202,8 +174,8 @@ describe('Local driver | copy', () => {
   })
 
   it('create intermediate directories when copying a file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.copy('foo.txt', 'baz/bar.txt')
@@ -213,8 +185,8 @@ describe('Local driver | copy', () => {
   })
 
   it("return error when source doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     try {
       await driver.copy('foo.txt', 'bar.txt')
@@ -226,8 +198,8 @@ describe('Local driver | copy', () => {
   })
 
   it('overwrite destination when already exists', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.put('bar.txt', 'hi world')
@@ -239,13 +211,9 @@ describe('Local driver | copy', () => {
 })
 
 describe('Local driver | move', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('move file from within the disk root', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.move('foo.txt', 'bar.txt')
@@ -256,8 +224,8 @@ describe('Local driver | move', () => {
   })
 
   it('create intermediate directories when moving a file', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.move('foo.txt', 'baz/bar.txt')
@@ -268,8 +236,8 @@ describe('Local driver | move', () => {
   })
 
   it("return error when source doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     try {
       await driver.move('foo.txt', 'baz/bar.txt')
@@ -281,8 +249,8 @@ describe('Local driver | move', () => {
   })
 
   it('overwrite destination when already exists', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
     await driver.put('baz/bar.txt', 'hi world')
@@ -295,13 +263,9 @@ describe('Local driver | move', () => {
 })
 
 describe('Local driver | get', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('get file contents', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
 
@@ -310,8 +274,8 @@ describe('Local driver | get', () => {
   })
 
   it('get file contents as a stream', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
 
@@ -326,8 +290,8 @@ describe('Local driver | get', () => {
   })
 
   it("return error when file doesn't exists", async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     try {
       await driver.get('foo.txt')
@@ -340,13 +304,9 @@ describe('Local driver | get', () => {
 })
 
 describe('Local driver | getStats', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('get file stats', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     await driver.put('foo.txt', 'hello world')
 
@@ -356,8 +316,8 @@ describe('Local driver | getStats', () => {
   })
 
   it('return error when file is missing', async () => {
-    const config: LocalDriverConfig = { root: TEST_ROOT }
-    const driver = new LocalDriver(config)
+    const config: FakeDriverConfig = {}
+    const driver = new FakeDriver(config)
 
     try {
       await driver.getStats('foo.txt')
@@ -370,13 +330,8 @@ describe('Local driver | getStats', () => {
 })
 
 describe('Local driver | getUrl', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('get url to a given file', async () => {
-    const config: LocalDriverConfig = {
-      root: TEST_ROOT,
+    const config: FakeDriverConfig = {
       serveFiles: {
         makeUrl(location) {
           return (
@@ -401,7 +356,7 @@ describe('Local driver | getUrl', () => {
         }
       }
     }
-    const driver = new LocalDriver(config)
+    const driver = new FakeDriver(config)
 
     const url = await driver.getUrl('foo.txt')
     expect(url).toBe('/uploads/foo.txt')
@@ -409,13 +364,8 @@ describe('Local driver | getUrl', () => {
 })
 
 describe('Local driver | getSignedUrl', () => {
-  afterEach(async () => {
-    await cleanup()
-  })
-
   it('get signed url to a given file', async () => {
-    const config: LocalDriverConfig = {
-      root: TEST_ROOT,
+    const config: FakeDriverConfig = {
       serveFiles: {
         makeUrl(location) {
           return (
@@ -440,7 +390,7 @@ describe('Local driver | getSignedUrl', () => {
         }
       }
     }
-    const driver = new LocalDriver(config)
+    const driver = new FakeDriver(config)
 
     const url = await driver.getSignedUrl('foo.txt')
     expect(url).toMatch(/\/uploads\/foo\.txt\?sign=.*/)

--- a/packages/files/tests/drivers/local.spec.ts
+++ b/packages/files/tests/drivers/local.spec.ts
@@ -1,0 +1,448 @@
+import { tmpdir } from 'os'
+import path, { join } from 'path'
+import { Readable } from 'stream'
+import rimraf from 'rimraf'
+
+import { pipe, Str } from '@apoyo/std'
+
+import {
+  CannotCopyFileException,
+  CannotGetMetaDataException,
+  CannotMoveFileException,
+  CannotReadFileException,
+  FileException,
+  LocalDriver,
+  LocalDriverConfig
+} from '../../src'
+
+const TEST_ROOT = path.resolve(tmpdir(), 'tests')
+
+const cleanup = async () => {
+  return new Promise<void>((resolve, reject) => rimraf(TEST_ROOT, {}, (err) => (err ? reject(err) : resolve())))
+}
+
+describe('Local driver | put', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('write file to the destination', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+
+    const contents = await driver.get('foo.txt')
+
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('create intermediate directories when missing', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('bar/baz/foo.txt', 'hello world')
+
+    const contents = await driver.get('bar/baz/foo.txt')
+
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('overwrite destination when file already exists', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hi world')
+    await driver.put('foo.txt', 'hello world')
+
+    const contents = await driver.get('foo.txt')
+
+    expect(contents.toString()).toBe('hello world')
+  })
+})
+
+describe('Local driver | putStream', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('write stream to a file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    const stream = new Readable({
+      read() {
+        this.push('hello world')
+        this.push(null)
+      }
+    })
+
+    expect(stream.readable).toBe(true)
+    await driver.putStream('foo.txt', stream)
+    expect(stream.readable).toBe(false)
+
+    const contents = await driver.get('foo.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('create intermediate directories when writing a stream to a file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    const stream = new Readable({
+      read() {
+        this.push('hello world')
+        this.push(null)
+      }
+    })
+
+    expect(stream.readable).toBe(true)
+    await driver.putStream('bar/baz/foo.txt', stream)
+    expect(stream.readable).toBe(false)
+
+    const contents = await driver.get('bar/baz/foo.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('overwrite existing file when stream to a file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    const stream = new Readable({
+      read() {
+        this.push('hello world')
+        this.push(null)
+      }
+    })
+
+    expect(stream.readable).toBe(true)
+    await driver.put('foo.txt', 'hi world')
+    await driver.putStream('foo.txt', stream)
+    expect(stream.readable).toBe(false)
+
+    const contents = await driver.get('foo.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+})
+
+describe('Local driver | exists', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('return true when a file exists', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('bar/baz/foo.txt', 'bar')
+    expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
+  })
+
+  it("return false when a file doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    expect(await driver.exists('foo.txt')).toBe(false)
+  })
+
+  it("return false when a file parent directory doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+  })
+})
+
+describe('Local driver | delete', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('remove file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('bar/baz/foo.txt', 'bar')
+    await driver.delete('bar/baz/foo.txt')
+
+    expect(await driver.exists(join(TEST_ROOT, 'bar/baz/foo.txt'))).toBe(false)
+  })
+
+  it('do not error when trying to remove a non-existing file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.delete('foo.txt')
+    expect(await driver.exists(join(TEST_ROOT, 'foo.txt'))).toBe(false)
+  })
+
+  it("do not error when file parent directory doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.delete('bar/baz/foo.txt')
+    expect(await driver.exists(join(TEST_ROOT, 'bar/baz/foo.txt'))).toBe(false)
+  })
+})
+
+describe('Local driver | copy', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('copy file from within the disk root', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.copy('foo.txt', 'bar.txt')
+
+    const contents = await driver.get('bar.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('create intermediate directories when copying a file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.copy('foo.txt', 'baz/bar.txt')
+
+    const contents = await driver.get('baz/bar.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it("return error when source doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    try {
+      await driver.copy('foo.txt', 'bar.txt')
+    } catch (error) {
+      expect(error).toBeInstanceOf(FileException)
+      expect(error).toBeInstanceOf(CannotCopyFileException)
+      expect(error.message).toBe('Cannot copy file from "foo.txt" to "bar.txt"')
+    }
+  })
+
+  it('overwrite destination when already exists', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.put('bar.txt', 'hi world')
+    await driver.copy('foo.txt', 'bar.txt')
+
+    const contents = await driver.get('bar.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+})
+
+describe('Local driver | move', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('move file from within the disk root', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.move('foo.txt', 'bar.txt')
+
+    const contents = await driver.get('bar.txt')
+    expect(contents.toString()).toBe('hello world')
+    expect(await driver.exists('foo.txt')).toBe(false)
+  })
+
+  it('create intermediate directories when moving a file', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.move('foo.txt', 'baz/bar.txt')
+
+    const contents = await driver.get('baz/bar.txt')
+    expect(contents.toString()).toBe('hello world')
+    expect(await driver.exists('foo.txt')).toBe(false)
+  })
+
+  it("return error when source doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    try {
+      await driver.move('foo.txt', 'baz/bar.txt')
+    } catch (error) {
+      expect(error).toBeInstanceOf(FileException)
+      expect(error).toBeInstanceOf(CannotMoveFileException)
+      expect(error.message).toBe('Cannot move file from "foo.txt" to "baz/bar.txt"')
+    }
+  })
+
+  it('overwrite destination when already exists', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+    await driver.put('baz/bar.txt', 'hi world')
+
+    await driver.move('foo.txt', 'baz/bar.txt')
+
+    const contents = await driver.get('baz/bar.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+})
+
+describe('Local driver | get', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('get file contents', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+
+    const contents = await driver.get('foo.txt')
+    expect(contents.toString()).toBe('hello world')
+  })
+
+  it('get file contents as a stream', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+
+    const stream = await driver.getStream('foo.txt')
+
+    await new Promise<void>((resolve) => {
+      stream.on('data', (chunk) => {
+        expect(chunk.toString()).toBe('hello world')
+        resolve()
+      })
+    })
+  })
+
+  it("return error when file doesn't exists", async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    try {
+      await driver.get('foo.txt')
+    } catch (error) {
+      expect(error).toBeInstanceOf(FileException)
+      expect(error).toBeInstanceOf(CannotReadFileException)
+      expect(error.message).toBe('Cannot read file from location "foo.txt"')
+    }
+  })
+})
+
+describe('Local driver | getStats', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('get file stats', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    await driver.put('foo.txt', 'hello world')
+
+    const stats = await driver.getStats('foo.txt')
+    expect(stats.size).toBe(11)
+    expect(stats.modified).toBeInstanceOf(Date)
+  })
+
+  it('return error when file is missing', async () => {
+    const config: LocalDriverConfig = { root: TEST_ROOT }
+    const driver = new LocalDriver(config)
+
+    try {
+      await driver.getStats('foo.txt')
+    } catch (error) {
+      expect(error).toBeInstanceOf(FileException)
+      expect(error).toBeInstanceOf(CannotGetMetaDataException)
+      expect(error.message).toBe('Unable to retrieve the "stats" for file at location "foo.txt"')
+    }
+  })
+})
+
+describe('Local driver | getUrl', () => {
+  afterEach(async () => {
+    // await cleanup()
+  })
+
+  it('get url to a given file', async () => {
+    const config: LocalDriverConfig = {
+      root: TEST_ROOT,
+      serveFiles: {
+        makeUrl(location) {
+          return (
+            '/uploads/' +
+            pipe(
+              location,
+              Str.replace(path.sep, '/'),
+              Str.trimWhile((c) => c === '/')
+            )
+          )
+        },
+        makeSignedUrl(location, _options) {
+          return (
+            '/uploads/' +
+            pipe(
+              location,
+              Str.replace(path.sep, '/'),
+              Str.trimWhile((c) => c === '/')
+            ) +
+            '?sign=xxxx'
+          )
+        }
+      }
+    }
+    const driver = new LocalDriver(config)
+
+    const url = await driver.getUrl('foo.txt')
+    expect(url).toBe('/uploads/foo.txt')
+  })
+})
+
+describe('Local driver | getSignedUrl', () => {
+  afterEach(async () => {
+    await cleanup()
+  })
+
+  it('get signed url to a given file', async () => {
+    const config: LocalDriverConfig = {
+      root: TEST_ROOT,
+      serveFiles: {
+        makeUrl(location) {
+          return (
+            '/uploads/' +
+            pipe(
+              location,
+              Str.replace(path.sep, '/'),
+              Str.trimWhile((c) => c === '/')
+            )
+          )
+        },
+        makeSignedUrl(location, _options) {
+          return (
+            '/uploads/' +
+            pipe(
+              location,
+              Str.replace(path.sep, '/'),
+              Str.trimWhile((c) => c === '/')
+            ) +
+            '?sign=xxxx'
+          )
+        }
+      }
+    }
+    const driver = new LocalDriver(config)
+
+    const url = await driver.getSignedUrl('foo.txt')
+    expect(url).toMatch(/\/uploads\/foo\.txt\?sign=.*/)
+  })
+})

--- a/packages/files/tests/process.spec.ts
+++ b/packages/files/tests/process.spec.ts
@@ -1,5 +1,0 @@
-describe('Files', () => {
-  it('should return ok', async () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/files/tests/process.spec.ts
+++ b/packages/files/tests/process.spec.ts
@@ -1,0 +1,5 @@
+describe('Files', () => {
+  it('should return ok', async () => {
+    expect(true).toBe(true)
+  })
+})

--- a/packages/files/tsconfig.json
+++ b/packages/files/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "."
+  }
+}

--- a/packages/files/tsup.config.ts
+++ b/packages/files/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: false,
+  sourcemap: false,
+  dts: true,
+  clean: true,
+  minify: false,
+  format: ['cjs', 'esm']
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,7 +106,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@apoyo/files@workspace:packages/files"
   dependencies:
-    "@apoyo/std": "workspace:^"
+    "@apoyo/std": 0.0.15
     "@types/etag": ^1.8.1
     "@types/fs-extra": ^9.0.13
     "@types/jest": ^26.0.23
@@ -120,7 +120,7 @@ __metadata:
     tsup: ^6.1.2
     typescript: ^4.7.4
   peerDependencies:
-    "@apoyo/std": "workspace:^"
+    "@apoyo/std": 0.0.15
   languageName: unknown
   linkType: soft
 
@@ -184,7 +184,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apoyo/std@^0.0.15, @apoyo/std@workspace:^, @apoyo/std@workspace:packages/std":
+"@apoyo/std@0.0.15, @apoyo/std@^0.0.15, @apoyo/std@workspace:packages/std":
   version: 0.0.0-use.local
   resolution: "@apoyo/std@workspace:packages/std"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@apoyo/files-gcs@workspace:packages/files-gcs":
+  version: 0.0.0-use.local
+  resolution: "@apoyo/files-gcs@workspace:packages/files-gcs"
+  dependencies:
+    "@apoyo/files": 0.0.1
+    "@google-cloud/storage": ^6.4.1
+    "@types/jest": ^26.0.23
+    "@types/node": ^14.18.21
+    jest: ^26.4.2
+    ts-jest: ^26.3.0
+    ts-node: ^8.0.2
+    tsup: ^6.1.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@apoyo/files": 0.0.1
+  languageName: unknown
+  linkType: soft
+
 "@apoyo/files-s3@workspace:packages/files-s3":
   version: 0.0.0-use.local
   resolution: "@apoyo/files-s3@workspace:packages/files-s3"
@@ -1762,6 +1780,56 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@google-cloud/paginator@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@google-cloud/paginator@npm:3.0.7"
+  dependencies:
+    arrify: ^2.0.0
+    extend: ^3.0.2
+  checksum: bdecce8a894a0c7f47f13d0e42b2fa142098e1dd34ce571b7216ad624057214baf9066ecf091501b3770da9d7be20b983eda30185c8c6596192cb748f8a0090c
+  languageName: node
+  linkType: hard
+
+"@google-cloud/projectify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@google-cloud/projectify@npm:3.0.0"
+  checksum: 4fa7ad689422b0b9c152fb00260e54e39d81678f9c51518bdb34bc57ee00604524fcdd5837fa97eb2f8ff4811afee3f345b1b0993bc4a2fa1b803bdd6554839a
+  languageName: node
+  linkType: hard
+
+"@google-cloud/promisify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@google-cloud/promisify@npm:3.0.0"
+  checksum: 5339e36bd5bc7957ae72b959e21c5d50fe028ad8eae9affb6e8e172aab715f3bf6a7b3c01720d6b4b67ea080d91dd30ac00f0dc88d455620c8bb10df263385a2
+  languageName: node
+  linkType: hard
+
+"@google-cloud/storage@npm:^6.4.1":
+  version: 6.4.1
+  resolution: "@google-cloud/storage@npm:6.4.1"
+  dependencies:
+    "@google-cloud/paginator": ^3.0.7
+    "@google-cloud/projectify": ^3.0.0
+    "@google-cloud/promisify": ^3.0.0
+    abort-controller: ^3.0.0
+    arrify: ^2.0.0
+    async-retry: ^1.3.3
+    compressible: ^2.0.12
+    duplexify: ^4.0.0
+    ent: ^2.2.0
+    extend: ^3.0.2
+    gaxios: ^5.0.0
+    google-auth-library: ^8.0.1
+    mime: ^3.0.0
+    mime-types: ^2.0.8
+    p-limit: ^3.0.1
+    retry-request: ^5.0.0
+    teeny-request: ^8.0.0
+    uuid: ^8.0.0
+  checksum: 14e7b79b5ed896f1598bb16a9d5f8ca0432c1d5a5225e563b6ab6dbb397f20196eb4a5c45bdfd866dd1f74f486a9155570cb0d41dc1b170b16555e3e50c96094
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.9.2":
   version: 0.9.5
   resolution: "@humanwhocodes/config-array@npm:0.9.5"
@@ -2870,6 +2938,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arrify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "arrify@npm:2.0.1"
+  checksum: 067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
+  languageName: node
+  linkType: hard
+
 "asap@npm:^2.0.0":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
@@ -2895,6 +2970,15 @@ __metadata:
   version: 1.3.2
   resolution: "async-lock@npm:1.3.2"
   checksum: d66d6163d4a5c1d09f60118d850da53394a2b8ccae28e0613a88fc33e8b0c2b3266c4f6ed0bc5c9889ad8a926fc886a3e06600775c7264289e8814e39018cd7f
+  languageName: node
+  linkType: hard
+
+"async-retry@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "async-retry@npm:1.3.3"
+  dependencies:
+    retry: 0.13.1
+  checksum: 38a7152ff7265a9321ea214b9c69e8224ab1febbdec98efbbde6e562f17ff68405569b796b1c5271f354aef8783665d29953f051f68c1fc45306e61aec82fdc4
   languageName: node
   linkType: hard
 
@@ -3012,7 +3096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
+"base64-js@npm:^1.0.2, base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -3031,6 +3115,13 @@ __metadata:
     mixin-deep: ^1.2.0
     pascalcase: ^0.1.1
   checksum: a4a146b912e27eea8f66d09cb0c9eab666f32ce27859a7dfd50f38cd069a2557b39f16dba1bc2aecb3b44bf096738dd207b7970d99b0318423285ab1b1994edd
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.0":
+  version: 9.1.0
+  resolution: "bignumber.js@npm:9.1.0"
+  checksum: 52ec2bb5a3874d7dc1a1018f28f8f7aff4683515ffd09d6c2d93191343c76567ae0ee32cc45149d53afb2b904bc62ed471a307b35764beea7e9db78e56bef6c6
   languageName: node
   linkType: hard
 
@@ -3160,6 +3251,13 @@ __metadata:
   dependencies:
     node-int64: ^0.4.0
   checksum: 9ba4dc58ce86300c862bffc3ae91f00b2a03b01ee07f3564beeeaf82aa243b8b03ba53f123b0b842c190d4399b94697970c8e7cf7b1ea44b61aa28c3526a4449
+  languageName: node
+  linkType: hard
+
+"buffer-equal-constant-time@npm:1.0.1":
+  version: 1.0.1
+  resolution: "buffer-equal-constant-time@npm:1.0.1"
+  checksum: 80bb945f5d782a56f374b292770901065bad21420e34936ecbe949e57724b4a13874f735850dd1cc61f078773c4fb5493a41391e7bda40d1fa388d6bd80daaab
   languageName: node
   linkType: hard
 
@@ -3596,6 +3694,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"compressible@npm:^2.0.12":
+  version: 2.0.18
+  resolution: "compressible@npm:2.0.18"
+  dependencies:
+    mime-db: ">= 1.43.0 < 2"
+  checksum: 58321a85b375d39230405654721353f709d0c1442129e9a17081771b816302a012471a9b8f4864c7dbe02eef7f2aaac3c614795197092262e94b409c9be108f0
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -3942,10 +4049,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"duplexify@npm:^4.0.0":
+  version: 4.1.2
+  resolution: "duplexify@npm:4.1.2"
+  dependencies:
+    end-of-stream: ^1.4.1
+    inherits: ^2.0.3
+    readable-stream: ^3.1.1
+    stream-shift: ^1.0.0
+  checksum: 964376c61c0e92f6ed0694b3ba97c84f199413dc40ab8dfdaef80b7a7f4982fcabf796214e28ed614a5bc1ec45488a29b81e7d46fa3f5ddf65bcb118c20145ad
+  languageName: node
+  linkType: hard
+
 "eastasianwidth@npm:^0.2.0":
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
+"ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "ecdsa-sig-formatter@npm:1.0.11"
+  dependencies:
+    safe-buffer: ^5.0.1
+  checksum: 207f9ab1c2669b8e65540bce29506134613dd5f122cccf1e6a560f4d63f2732d427d938f8481df175505aad94583bcb32c688737bb39a6df0625f903d6d93c03
   languageName: node
   linkType: hard
 
@@ -4007,12 +4135,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"end-of-stream@npm:^1.1.0":
+"end-of-stream@npm:^1.1.0, end-of-stream@npm:^1.4.1":
   version: 1.4.4
   resolution: "end-of-stream@npm:1.4.4"
   dependencies:
     once: ^1.4.0
   checksum: 530a5a5a1e517e962854a31693dbb5c0b2fc40b46dad2a56a2deec656ca040631124f4795823acc68238147805f8b021abbe221f4afed5ef3c8e8efc2024908b
+  languageName: node
+  linkType: hard
+
+"ent@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "ent@npm:2.2.0"
+  checksum: f588b5707d6fef36011ea10d530645912a69530a1eb0831f8708c498ac028363a7009f45cfadd28ceb4dafd9ac17ec15213f88d09ce239cd033cfe1328dd7d7d
   languageName: node
   linkType: hard
 
@@ -4674,6 +4809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"extend@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: a50a8309ca65ea5d426382ff09f33586527882cf532931cb08ca786ea3146c0553310bda688710ff61d7668eba9f96b923fe1420cdf56a2c3eaf30fcab87b515
+  languageName: node
+  linkType: hard
+
 "extglob@npm:^2.0.4":
   version: 2.0.4
   resolution: "extglob@npm:2.0.4"
@@ -4749,6 +4891,13 @@ __metadata:
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: a851cbddc451745662f8f00ddb622d6766f9bd97642dabfd9a405fb0d646d69fc0b9a1243cbf67f5f18a39f40f6fa821737651ff1bceeba06c9992ca2dc5bd3d
+  languageName: node
+  linkType: hard
+
+"fast-text-encoding@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "fast-text-encoding@npm:1.0.6"
+  checksum: 9d58f694314b3283e785bf61954902536da228607ad246905e30256f9ab8331f780ac987e7222c9f5eafd04168d07e12b8054c85cedb76a2c05af0e82387a903
   languageName: node
   linkType: hard
 
@@ -5012,6 +5161,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^5.0.0, gaxios@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "gaxios@npm:5.0.1"
+  dependencies:
+    extend: ^3.0.2
+    https-proxy-agent: ^5.0.0
+    is-stream: ^2.0.0
+    node-fetch: ^2.6.7
+  checksum: 65464122a5be72084d07947536d18a0dcebd115b28cbcd19da8a98763a67c8c8fde995bf2f358251397c939df9d2ff84f54628a94f634a98a16c7b7553cdb4a5
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "gcp-metadata@npm:5.0.0"
+  dependencies:
+    gaxios: ^5.0.0
+    json-bigint: ^1.0.0
+  checksum: b75635e564a39ef0a6ebbff0daa97cea37382c3d6f0d7a6a0406e03a275de804a74e3f3d410d5313a6c9dd3496023e96bc81474917fa8369974398eb069d9645
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -5179,6 +5350,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^8.0.1":
+  version: 8.4.0
+  resolution: "google-auth-library@npm:8.4.0"
+  dependencies:
+    arrify: ^2.0.0
+    base64-js: ^1.3.0
+    ecdsa-sig-formatter: ^1.0.11
+    fast-text-encoding: ^1.0.0
+    gaxios: ^5.0.0
+    gcp-metadata: ^5.0.0
+    gtoken: ^6.1.0
+    jws: ^4.0.0
+    lru-cache: ^6.0.0
+  checksum: 4f3f52399c851dff3be797f888e675dbb6099613fcd934aece0d1527b9e9a77e5aadc9be12d137981d2d820a59050b0baf29ea126d2722e20a3e1adf425c93e6
+  languageName: node
+  linkType: hard
+
+"google-p12-pem@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "google-p12-pem@npm:4.0.1"
+  dependencies:
+    node-forge: ^1.3.1
+  bin:
+    gp12-pem: build/src/bin/gp12-pem.js
+  checksum: 59a5026331ea67455672e83770da29f09d979f02e06cb2227ea5916f8cca437887c2d3869f2602a686dc84437886ae9d2ac010780803cbe8e5f161c2d02d8efd
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
@@ -5197,6 +5396,17 @@ __metadata:
   version: 1.3.0
   resolution: "growly@npm:1.3.0"
   checksum: 53cdecd4c16d7d9154a9061a9ccb87d602e957502ca69b529d7d1b2436c2c0b700ec544fc6b3e4cd115d59b81e62e44ce86bd0521403b579d3a2a97d7ce72a44
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^6.1.0":
+  version: 6.1.1
+  resolution: "gtoken@npm:6.1.1"
+  dependencies:
+    gaxios: ^5.0.1
+    google-p12-pem: ^4.0.0
+    jws: ^4.0.0
+  checksum: f063ed3f418f5a9c33fbe599b09f56a55b18f6c8d2913f11cc2fc5025d53b96fd6ab1b4deb2c7631167d6b89d0939e4ea77f94767fcf338862ffda8911250980
   languageName: node
   linkType: hard
 
@@ -6416,6 +6626,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: ^9.0.0
+  checksum: c67bb93ccb3c291e60eb4b62931403e378906aab113ec1c2a8dd0f9a7f065ad6fd9713d627b732abefae2e244ac9ce1721c7a3142b2979532f12b258634ce6f6
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -6458,6 +6677,27 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
+  languageName: node
+  linkType: hard
+
+"jwa@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "jwa@npm:2.0.0"
+  dependencies:
+    buffer-equal-constant-time: 1.0.1
+    ecdsa-sig-formatter: 1.0.11
+    safe-buffer: ^5.0.1
+  checksum: 8f00b71ad5fe94cb55006d0d19202f8f56889109caada2f7eeb63ca81755769ce87f4f48101967f398462e3b8ae4faebfbd5a0269cb755dead5d63c77ba4d2f1
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jws@npm:4.0.0"
+  dependencies:
+    jwa: ^2.0.0
+    safe-buffer: ^5.0.1
+  checksum: d68d07aa6d1b8cb35c363a9bd2b48f15064d342a5d9dc18a250dbbce8dc06bd7e4792516c50baa16b8d14f61167c19e851fd7f66b59ecc68b7f6a013759765f7
   languageName: node
   linkType: hard
 
@@ -6837,6 +7077,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:1.52.0, mime-db@npm:>= 1.43.0 < 2":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.0.8":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: 1.52.0
+  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.34
   resolution: "mime-types@npm:2.1.34"
@@ -6861,6 +7117,15 @@ __metadata:
   bin:
     mime: cli.js
   checksum: 1497ba7b9f6960694268a557eae24b743fd2923da46ec392b042469f4b901721ba0adcf8b0d3c2677839d0e243b209d76e5edcbd09cfdeffa2dfb6bb4df4b862
+  languageName: node
+  linkType: hard
+
+"mime@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mime@npm:3.0.0"
+  bin:
+    mime: cli.js
+  checksum: f43f9b7bfa64534e6b05bd6062961681aeb406a5b53673b53b683f27fcc4e739989941836a355eef831f4478923651ecc739f4a5f6e20a76487b432bfd4db928
   languageName: node
   linkType: hard
 
@@ -7077,6 +7342,27 @@ __metadata:
   version: 1.0.5
   resolution: "nice-try@npm:1.0.5"
   checksum: 0b4af3b5bb5d86c289f7a026303d192a7eb4417231fe47245c460baeabae7277bcd8fd9c728fb6bd62c30b3e15cd6620373e2cf33353b095d8b403d3e8a15aff
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
+"node-forge@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "node-forge@npm:1.3.1"
+  checksum: 08fb072d3d670599c89a1704b3e9c649ff1b998256737f0e06fbd1a5bf41cae4457ccaee32d95052d80bbafd9ffe01284e078c8071f0267dc9744e51c5ed42a9
   languageName: node
   linkType: hard
 
@@ -7399,6 +7685,15 @@ __metadata:
   dependencies:
     p-try: ^2.0.0
   checksum: 84ff17f1a38126c3314e91ecfe56aecbf36430940e2873dadaa773ffe072dc23b7af8e46d4b6485d302a11673fe94c6b67ca2cfbb60c989848b02100d0594ac1
+  languageName: node
+  linkType: hard
+
+"p-limit@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "p-limit@npm:3.1.0"
+  dependencies:
+    yocto-queue: ^0.1.0
+  checksum: 7c3690c4dbf62ef625671e20b7bdf1cbc9534e83352a2780f165b0d3ceba21907e77ad63401708145ca4e25bfc51636588d89a8c0aeb715e6c37d1c066430360
   languageName: node
   linkType: hard
 
@@ -7856,7 +8151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -8017,6 +8312,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"retry-request@npm:^5.0.0":
+  version: 5.0.1
+  resolution: "retry-request@npm:5.0.1"
+  dependencies:
+    debug: ^4.1.1
+    extend: ^3.0.2
+  checksum: 8da06c4d0ae59bd48ba38f2a69235f90fd87001a195fcde2fcf91614e3bc16704d0dada8e790a55ff902522e733db0d7bd3bf3c2f26be8b943a7062cd06f1b91
+  languageName: node
+  linkType: hard
+
+"retry@npm:0.13.1":
+  version: 0.13.1
+  resolution: "retry@npm:0.13.1"
+  checksum: 47c4d5be674f7c13eee4cfe927345023972197dbbdfba5d3af7e461d13b44de1bfd663bfc80d2f601f8ef3fc8164c16dd99655a221921954a65d044a2fc1233b
+  languageName: node
+  linkType: hard
+
 "retry@npm:^0.12.0":
   version: 0.12.0
   resolution: "retry@npm:0.12.0"
@@ -8088,7 +8400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.2.1, safe-buffer@npm:~5.2.0":
+"safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
   checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
@@ -8620,6 +8932,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-events@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "stream-events@npm:1.0.5"
+  dependencies:
+    stubs: ^3.0.0
+  checksum: 969ce82e34bfbef5734629cc06f9d7f3705a9ceb8fcd6a526332f9159f1f8bbfdb1a453f3ced0b728083454f7706adbbe8428bceb788a0287ca48ba2642dc3fc
+  languageName: node
+  linkType: hard
+
+"stream-shift@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "stream-shift@npm:1.0.1"
+  checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
+  languageName: node
+  linkType: hard
+
 "string-argv@npm:^0.3.1":
   version: 0.3.1
   resolution: "string-argv@npm:0.3.1"
@@ -8718,6 +9046,13 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 492f73e27268f9b1c122733f28ecb0e7e8d8a531a6662efbd08e22cccb3f9475e90a1b82cab06a392f6afae6d2de636f977e231296400d0ec5304ba70f166443
+  languageName: node
+  linkType: hard
+
+"stubs@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "stubs@npm:3.0.0"
+  checksum: dec7b82186e3743317616235c59bfb53284acc312cb9f4c3e97e2205c67a5c158b0ca89db5927e52351582e90a2672822eeaec9db396e23e56893d2a8676e024
   languageName: node
   linkType: hard
 
@@ -8820,6 +9155,19 @@ __metadata:
     mkdirp: ^1.0.3
     yallist: ^4.0.0
   checksum: a04c07bb9e2d8f46776517d4618f2406fb977a74d914ad98b264fc3db0fe8224da5bec11e5f8902c5b9bcb8ace22d95fbe3c7b36b8593b7dfc8391a25898f32f
+  languageName: node
+  linkType: hard
+
+"teeny-request@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "teeny-request@npm:8.0.1"
+  dependencies:
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    node-fetch: ^2.6.1
+    stream-events: ^1.0.5
+    uuid: ^8.0.0
+  checksum: de37b23d5fe480dd36e99eb4e80f09d18737da0841f9d3f502b05c96183361ec7aef70db211d51d3527f967cbc94593781a392be6d285df576e5a74cc970627b
   languageName: node
   linkType: hard
 
@@ -8996,6 +9344,13 @@ __metadata:
   dependencies:
     punycode: ^2.1.1
   checksum: ffe6049b9dca3ae329b059aada7f515b0f0064c611b39b51ff6b53897e954650f6f63d9319c6c008d36ead477c7b55e5f64c9dc60588ddc91ff720d64eb710b3
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
   languageName: node
   linkType: hard
 
@@ -9323,7 +9678,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
+"uuid@npm:^8.0.0, uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
@@ -9403,6 +9758,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
 "webidl-conversions@npm:^4.0.2":
   version: 4.0.2
   resolution: "webidl-conversions@npm:4.0.2"
@@ -9437,6 +9799,16 @@ __metadata:
   version: 2.3.0
   resolution: "whatwg-mimetype@npm:2.3.0"
   checksum: 23eb885940bcbcca4ff841c40a78e9cbb893ec42743993a42bf7aed16085b048b44b06f3402018931687153550f9a32d259dfa524e4f03577ab898b6965e5383
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: ~0.0.3
+    webidl-conversions: ^3.0.0
+  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 
@@ -9718,5 +10090,12 @@ __metadata:
   version: 3.1.1
   resolution: "yn@npm:3.1.1"
   checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
+  languageName: node
+  linkType: hard
+
+"yocto-queue@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "yocto-queue@npm:0.1.0"
+  checksum: f77b3d8d00310def622123df93d4ee654fc6a0096182af8bd60679ddcdfb3474c56c6c7190817c84a2785648cdee9d721c0154eb45698c62176c322fb46fc700
   languageName: node
   linkType: hard

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,10 +148,12 @@ __metadata:
     "@types/fs-extra": ^9.0.13
     "@types/jest": ^26.0.23
     "@types/node": ^14.18.21
+    "@types/rimraf": ^3
     etag: ^1.8.1
     fs-extra: ^10.1.0
     jest: ^26.4.2
     memfs: ^3.4.7
+    rimraf: ^3.0.2
     ts-jest: ^26.3.0
     ts-node: ^8.0.2
     tsup: ^6.1.2
@@ -2572,6 +2574,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/glob@npm:*":
+  version: 8.0.0
+  resolution: "@types/glob@npm:8.0.0"
+  dependencies:
+    "@types/minimatch": "*"
+    "@types/node": "*"
+  checksum: 1817b05f5a8aed851d102a65b5e926d5c777bef927ea62b36d635860eef5364f2046bb5a692d135b6f2b28f34e4a9d44ade9396122c0845bcc7636d35f624747
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.2":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
@@ -2627,6 +2639,13 @@ __metadata:
   version: 1.3.2
   resolution: "@types/mime@npm:1.3.2"
   checksum: 0493368244cced1a69cb791b485a260a422e6fcc857782e1178d1e6f219f1b161793e9f87f5fae1b219af0f50bee24fcbe733a18b4be8fdd07a38a8fb91146fd
+  languageName: node
+  linkType: hard
+
+"@types/minimatch@npm:*":
+  version: 5.1.1
+  resolution: "@types/minimatch@npm:5.1.1"
+  checksum: 75d7cc5b0964dab6993dbdc7a4d0f082459260fec3210baa907856fb2cf6bca7112717422b488b81953e07f8fc36466cdaa9e9684942b9210d240ddaa2fdf42a
   languageName: node
   linkType: hard
 
@@ -2695,6 +2714,16 @@ __metadata:
   version: 1.2.4
   resolution: "@types/range-parser@npm:1.2.4"
   checksum: b7c0dfd5080a989d6c8bb0b6750fc0933d9acabeb476da6fe71d8bdf1ab65e37c136169d84148034802f48378ab94e3c37bb4ef7656b2bec2cb9c0f8d4146a95
+  languageName: node
+  linkType: hard
+
+"@types/rimraf@npm:^3":
+  version: 3.0.2
+  resolution: "@types/rimraf@npm:3.0.2"
+  dependencies:
+    "@types/glob": "*"
+    "@types/node": "*"
+  checksum: b47fa302f46434cba704d20465861ad250df79467d3d289f9d6490d3aeeb41e8cb32dd80bd1a8fd833d1e185ac719fbf9be12e05ad9ce9be094d8ee8f1405347
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@apoyo/files-azure@workspace:packages/files-azure":
+  version: 0.0.0-use.local
+  resolution: "@apoyo/files-azure@workspace:packages/files-azure"
+  dependencies:
+    "@apoyo/files": 0.0.1
+    "@azure/identity": ^2.1.0
+    "@azure/storage-blob": ^12.11.0
+    "@types/jest": ^26.0.23
+    "@types/node": ^14.18.21
+    jest: ^26.4.2
+    ts-jest: ^26.3.0
+    ts-node: ^8.0.2
+    tsup: ^6.1.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@apoyo/files": 0.0.1
+  languageName: unknown
+  linkType: soft
+
 "@apoyo/files-gcs@workspace:packages/files-gcs":
   version: 0.0.0-use.local
   resolution: "@apoyo/files-gcs@workspace:packages/files-gcs"
@@ -1334,6 +1353,204 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/abort-controller@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@azure/abort-controller@npm:1.1.0"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: 0f45e504d4aea799486867179afe7589255f6c111951279958e9d0aa5faebb2c96b8f88e3e3c958ce07b02bcba0b0cddb1bbec94705f573a48ecdb93eec1a92a
+  languageName: node
+  linkType: hard
+
+"@azure/core-auth@npm:^1.3.0, @azure/core-auth@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@azure/core-auth@npm:1.4.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    tslib: ^2.2.0
+  checksum: 1c76c296fe911ad39fc780b033c25a92c41c5a15f011b816d42c13584f627a4dd153dfb4334900ec93eb5b006e14bdda37e8412a7697c5a9636a0abaccffad39
+  languageName: node
+  linkType: hard
+
+"@azure/core-client@npm:^1.4.0":
+  version: 1.6.1
+  resolution: "@azure/core-client@npm:1.6.1"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-rest-pipeline": ^1.9.1
+    "@azure/core-tracing": ^1.0.0
+    "@azure/core-util": ^1.0.0
+    "@azure/logger": ^1.0.0
+    tslib: ^2.2.0
+  checksum: 400890a9b5f0c8801ff92005c3cba7bb5124634e321735406731bef33688a79f23d28b49fccdfab90814dade41a13f3d3cb99f80151a2bff17628416e811afb6
+  languageName: node
+  linkType: hard
+
+"@azure/core-http@npm:^2.0.0":
+  version: 2.2.6
+  resolution: "@azure/core-http@npm:2.2.6"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.3.0
+    "@azure/core-tracing": 1.0.0-preview.13
+    "@azure/logger": ^1.0.0
+    "@types/node-fetch": ^2.5.0
+    "@types/tunnel": ^0.0.3
+    form-data: ^4.0.0
+    node-fetch: ^2.6.7
+    process: ^0.11.10
+    tough-cookie: ^4.0.0
+    tslib: ^2.2.0
+    tunnel: ^0.0.6
+    uuid: ^8.3.0
+    xml2js: ^0.4.19
+  checksum: 0faa5475c9fd9f0464da4cd263544b7d20c892bdd63874e832ffea9993572043b9551a1ecdf101df26ecfae08ad30df6d519185835bbeb9187c5b8a0db4cfc1a
+  languageName: node
+  linkType: hard
+
+"@azure/core-lro@npm:^2.2.0":
+  version: 2.2.5
+  resolution: "@azure/core-lro@npm:2.2.5"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/logger": ^1.0.0
+    tslib: ^2.2.0
+  checksum: a7456a3ef50aeb211b683517f8b07e2e1948b0258b73e3d1a03d32762877965e660d1b7c075b8343d1cbeb1f59480d51792183b725223d8c60ddad9ab0bf86a3
+  languageName: node
+  linkType: hard
+
+"@azure/core-paging@npm:^1.1.1":
+  version: 1.3.0
+  resolution: "@azure/core-paging@npm:1.3.0"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: 3fbf3d6474e2346f7c3ea8344a41bf41e053789efbbd29df78365e9c9ca66e143da3e5407d8c9dd5ddc82a65680185cd6f0ec851c48635776d18a6a605a98e78
+  languageName: node
+  linkType: hard
+
+"@azure/core-rest-pipeline@npm:^1.1.0, @azure/core-rest-pipeline@npm:^1.9.1":
+  version: 1.9.1
+  resolution: "@azure/core-rest-pipeline@npm:1.9.1"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-tracing": ^1.0.1
+    "@azure/core-util": ^1.0.0
+    "@azure/logger": ^1.0.0
+    form-data: ^4.0.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    tslib: ^2.2.0
+    uuid: ^8.3.0
+  checksum: 81912f54bcfc71405e5505a9ea8031e38f9811a2929e7482ac14beed4339128a4fc5480a6d21111fa9e81fe9a48315cb4f7b2de75cf7e9314db495e1030cd886
+  languageName: node
+  linkType: hard
+
+"@azure/core-tracing@npm:1.0.0-preview.13":
+  version: 1.0.0-preview.13
+  resolution: "@azure/core-tracing@npm:1.0.0-preview.13"
+  dependencies:
+    "@opentelemetry/api": ^1.0.1
+    tslib: ^2.2.0
+  checksum: bc3ea8dce1fc6bb6e4cb2e82ec0c361b3e6f6e18e162f352eb347e6991c6461ebc249f5d1b36402cc0d295e2a6bcbaa68014445d7f4293c0792a698c430f145e
+  languageName: node
+  linkType: hard
+
+"@azure/core-tracing@npm:^1.0.0, @azure/core-tracing@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@azure/core-tracing@npm:1.0.1"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: ae4309f8ab0b52c37f699594d58ee095782649f538bd6a0ee03e3fea042f55df7ad95c2e6dec22f5b8c3907e4bcf98d6ca98faaf480d446b73d41bbc1519d891
+  languageName: node
+  linkType: hard
+
+"@azure/core-util@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@azure/core-util@npm:1.0.0"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: a0a9cce9452f78babb224fa2ea5566811bd946c55e5c867ca75e6ecd7fcf796b2ec2aa7424e141f03d8e14141e80f048897d0d3c227a7ff0bbaa9ba3d2fc14c9
+  languageName: node
+  linkType: hard
+
+"@azure/identity@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@azure/identity@npm:2.1.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.3.0
+    "@azure/core-client": ^1.4.0
+    "@azure/core-rest-pipeline": ^1.1.0
+    "@azure/core-tracing": ^1.0.0
+    "@azure/core-util": ^1.0.0
+    "@azure/logger": ^1.0.0
+    "@azure/msal-browser": ^2.26.0
+    "@azure/msal-common": ^7.0.0
+    "@azure/msal-node": ^1.10.0
+    events: ^3.0.0
+    jws: ^4.0.0
+    open: ^8.0.0
+    stoppable: ^1.1.0
+    tslib: ^2.2.0
+    uuid: ^8.3.0
+  checksum: 1f29f1fd46c51f226da06e6e70f113d50f5ef0dd163e2ba1b8bc35cadcf98ccd829bff3d2bf4d90641c369e5d6b74b344f17abec10f2ae9469a74aeb9415d6d4
+  languageName: node
+  linkType: hard
+
+"@azure/logger@npm:^1.0.0":
+  version: 1.0.3
+  resolution: "@azure/logger@npm:1.0.3"
+  dependencies:
+    tslib: ^2.2.0
+  checksum: f3443c70c678a7449a5f3be09488a0a15711c506c9da6a81fa9e43178128ddf5db3abc02c99359d188e4ef47d703c5e5f206df71b0e01884245de3220ab1205b
+  languageName: node
+  linkType: hard
+
+"@azure/msal-browser@npm:^2.26.0":
+  version: 2.28.1
+  resolution: "@azure/msal-browser@npm:2.28.1"
+  dependencies:
+    "@azure/msal-common": ^7.3.0
+  checksum: 051cdf5ded5664209da7fca30fdad750773027905fa6a75de6711a203dc5eef15cfcad64744ad7b659888f8c0150b2ef759d2d2fa949f9f494fe5d9328e1415b
+  languageName: node
+  linkType: hard
+
+"@azure/msal-common@npm:^7.0.0, @azure/msal-common@npm:^7.3.0":
+  version: 7.3.0
+  resolution: "@azure/msal-common@npm:7.3.0"
+  checksum: 32dd4e3b97af269d6ba1e3432adcba014e51d1b5ecda759bb9c540598132ca7fe328c68deb979a2a44eefaa08dac15bf85f5f589b2a3bca3da3dda0bbe52e057
+  languageName: node
+  linkType: hard
+
+"@azure/msal-node@npm:^1.10.0":
+  version: 1.12.1
+  resolution: "@azure/msal-node@npm:1.12.1"
+  dependencies:
+    "@azure/msal-common": ^7.3.0
+    jsonwebtoken: ^8.5.1
+    uuid: ^8.3.0
+  checksum: 0c89f6a8f2554b40d245a0264eac4a943320f13bbfdc4aa2454e06dba8e11bee29bc7f43d39f8ebdb1b58565f773da6ec3356683453a728bce10cf2337344c51
+  languageName: node
+  linkType: hard
+
+"@azure/storage-blob@npm:^12.11.0":
+  version: 12.11.0
+  resolution: "@azure/storage-blob@npm:12.11.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-http": ^2.0.0
+    "@azure/core-lro": ^2.2.0
+    "@azure/core-paging": ^1.1.1
+    "@azure/core-tracing": 1.0.0-preview.13
+    "@azure/logger": ^1.0.0
+    events: ^3.0.0
+    tslib: ^2.2.0
+  checksum: f43501d66f10fb3f8e63b0e1e6e90827240e0ff41d722181c52b3abb13fa1b1b89dd985d0b6e488f6ffeee030e4afc1b6a9b6e2f18078ff6472dc494c5b199cb
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/code-frame@npm:7.16.7"
@@ -2194,6 +2411,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@opentelemetry/api@npm:^1.0.1":
+  version: 1.2.0
+  resolution: "@opentelemetry/api@npm:1.2.0"
+  checksum: 764efa81bf939200a8e80520a4735b23038abafc60c80420b007ae2bbb7ad843d806894414e95d974c2ef1b81d4ae8a3106804e1af7b5090240cfeb2467db099
+  languageName: node
+  linkType: hard
+
 "@repeaterjs/repeater@npm:^3.0.4":
   version: 3.0.4
   resolution: "@repeaterjs/repeater@npm:3.0.4"
@@ -2406,6 +2630,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-fetch@npm:^2.5.0":
+  version: 2.6.2
+  resolution: "@types/node-fetch@npm:2.6.2"
+  dependencies:
+    "@types/node": "*"
+    form-data: ^3.0.0
+  checksum: 6f73b1470000d303d25a6fb92875ea837a216656cb7474f66cdd67bb014aa81a5a11e7ac9c21fe19bee9ecb2ef87c1962bceeaec31386119d1ac86e4c30ad7a6
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 17.0.21
   resolution: "@types/node@npm:17.0.21"
@@ -2497,6 +2731,15 @@ __metadata:
   dependencies:
     "@types/superagent": "*"
   checksum: 291abc0d37abe833d517fcfd0c22d51e7d5ffea85ce990603a0d058afa7fe2465b1251d50642ddfd640f66d047029af512793215b612c39adbee72fae5b2ef4f
+  languageName: node
+  linkType: hard
+
+"@types/tunnel@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@types/tunnel@npm:0.0.3"
+  dependencies:
+    "@types/node": "*"
+  checksum: 53e23a1f9fb14a491c00425b2a4fc443817564d77be5e1b95fcbeb6d009551b62ea82ffc3e5ca0c6b9f6b186824ca6ec46e7450c1bcd6674a46d1325f0116e24
   languageName: node
   linkType: hard
 
@@ -3912,6 +4155,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: 0115fdb065e0490918ba271d7339c42453d209d4cb619dfe635870d906731eff3e1ade8028bb461ea27ce8264ec5e22c6980612d332895977e89c1bbc80fcee2
+  languageName: node
+  linkType: hard
+
 "define-property@npm:^0.2.5":
   version: 0.2.5
   resolution: "define-property@npm:0.2.5"
@@ -4636,7 +4886,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"events@npm:3.3.0":
+"events@npm:3.3.0, events@npm:^3.0.0":
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
@@ -5840,7 +6090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-docker@npm:^2.0.0":
+"is-docker@npm:^2.0.0, is-docker@npm:^2.1.1":
   version: 2.2.1
   resolution: "is-docker@npm:2.2.1"
   bin:
@@ -6680,6 +6930,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonwebtoken@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "jsonwebtoken@npm:8.5.1"
+  dependencies:
+    jws: ^3.2.2
+    lodash.includes: ^4.3.0
+    lodash.isboolean: ^3.0.3
+    lodash.isinteger: ^4.0.4
+    lodash.isnumber: ^3.0.3
+    lodash.isplainobject: ^4.0.6
+    lodash.isstring: ^4.0.1
+    lodash.once: ^4.0.0
+    ms: ^2.1.1
+    semver: ^5.6.0
+  checksum: 93c9e3f23c59b758ac88ba15f4e4753b3749dfce7a6f7c40fb86663128a1e282db085eec852d4e0cbca4cefdcd3a8275ee255dbd08fcad0df26ad9f6e4cc853a
+  languageName: node
+  linkType: hard
+
+"jwa@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "jwa@npm:1.4.1"
+  dependencies:
+    buffer-equal-constant-time: 1.0.1
+    ecdsa-sig-formatter: 1.0.11
+    safe-buffer: ^5.0.1
+  checksum: ff30ea7c2dcc61f3ed2098d868bf89d43701605090c5b21b5544b512843ec6fd9e028381a4dda466cbcdb885c2d1150f7c62e7168394ee07941b4098e1035e2f
+  languageName: node
+  linkType: hard
+
 "jwa@npm:^2.0.0":
   version: 2.0.0
   resolution: "jwa@npm:2.0.0"
@@ -6688,6 +6967,16 @@ __metadata:
     ecdsa-sig-formatter: 1.0.11
     safe-buffer: ^5.0.1
   checksum: 8f00b71ad5fe94cb55006d0d19202f8f56889109caada2f7eeb63ca81755769ce87f4f48101967f398462e3b8ae4faebfbd5a0269cb755dead5d63c77ba4d2f1
+  languageName: node
+  linkType: hard
+
+"jws@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "jws@npm:3.2.2"
+  dependencies:
+    jwa: ^1.4.1
+    safe-buffer: ^5.0.1
+  checksum: f0213fe5b79344c56cd443428d8f65c16bf842dc8cb8f5aed693e1e91d79c20741663ad6eff07a6d2c433d1831acc9814e8d7bada6a0471fbb91d09ceb2bf5c2
   languageName: node
   linkType: hard
 
@@ -6848,10 +7137,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.includes@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.includes@npm:4.3.0"
+  checksum: 71092c130515a67ab3bd928f57f6018434797c94def7f46aafa417771e455ce3a4834889f4267b17887d7f75297dfabd96231bf704fd2b8c5096dc4a913568b6
+  languageName: node
+  linkType: hard
+
+"lodash.isboolean@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isboolean@npm:3.0.3"
+  checksum: b70068b4a8b8837912b54052557b21fc4774174e3512ed3c5b94621e5aff5eb6c68089d0a386b7e801d679cd105d2e35417978a5e99071750aa2ed90bffd0250
+  languageName: node
+  linkType: hard
+
+"lodash.isinteger@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "lodash.isinteger@npm:4.0.4"
+  checksum: 6034821b3fc61a2ffc34e7d5644bb50c5fd8f1c0121c554c21ac271911ee0c0502274852845005f8651d51e199ee2e0cfebfe40aaa49c7fe617f603a8a0b1691
+  languageName: node
+  linkType: hard
+
+"lodash.isnumber@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isnumber@npm:3.0.3"
+  checksum: 913784275b565346255e6ae6a6e30b760a0da70abc29f3e1f409081585875105138cda4a429ff02577e1bc0a7ae2a90e0a3079a37f3a04c3d6c5aaa532f4cab2
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 29c6351f281e0d9a1d58f1a4c8f4400924b4c79f18dfc4613624d7d54784df07efaff97c1ff2659f3e085ecf4fff493300adc4837553104cef2634110b0d5337
+  languageName: node
+  linkType: hard
+
+"lodash.isstring@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.isstring@npm:4.0.1"
+  checksum: eaac87ae9636848af08021083d796e2eea3d02e80082ab8a9955309569cb3a463ce97fd281d7dc119e402b2e7d8c54a23914b15d2fc7fff56461511dc8937ba0
+  languageName: node
+  linkType: hard
+
 "lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: ad580b4bdbb7ca1f7abf7e1bce63a9a0b98e370cf40194b03380a46b4ed799c9573029599caebc1b14e3f24b111aef72b96674a56cfa105e0f5ac70546cdc005
+  languageName: node
+  linkType: hard
+
+"lodash.once@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "lodash.once@npm:4.1.1"
+  checksum: d768fa9f9b4e1dc6453be99b753906f58990e0c45e7b2ca5a3b40a33111e5d17f6edf2f768786e2716af90a8e78f8f91431ab8435f761fef00f9b0c256f6d245
   languageName: node
   linkType: hard
 
@@ -7620,6 +7958,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"open@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "open@npm:8.4.0"
+  dependencies:
+    define-lazy-prop: ^2.0.0
+    is-docker: ^2.1.1
+    is-wsl: ^2.2.0
+  checksum: e9545bec64cdbf30a0c35c1bdc310344adf8428a117f7d8df3c0af0a0a24c513b304916a6d9b11db0190ff7225c2d578885080b761ed46a3d5f6f1eebb98b63c
+  languageName: node
+  linkType: hard
+
 "optionator@npm:^0.8.1":
   version: 0.8.3
   resolution: "optionator@npm:0.8.3"
@@ -8001,6 +8350,13 @@ __metadata:
   version: 2.0.0
   resolution: "process-warning@npm:2.0.0"
   checksum: a2bb299835bced58e63cbe06a8fd6e048a648d3649e81b62c442b63112a3f0a86912e7b1a9c557daca30652232d3b0a7f1972fb87c36334e2a5a6f3d5c4a76c9
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "process@npm:0.11.10"
+  checksum: bfcce49814f7d172a6e6a14d5fa3ac92cc3d0c3b9feb1279774708a719e19acd673995226351a082a9ae99978254e320ccda4240ddc474ba31a76c79491ca7c3
   languageName: node
   linkType: hard
 
@@ -8456,6 +8812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.2.4
+  resolution: "sax@npm:1.2.4"
+  checksum: d3df7d32b897a2c2f28e941f732c71ba90e27c24f62ee918bd4d9a8cfb3553f2f81e5493c7f0be94a11c1911b643a9108f231dd6f60df3fa9586b5d2e3e9e1fe
+  languageName: node
+  linkType: hard
+
 "saxes@npm:^5.0.1":
   version: 5.0.1
   resolution: "saxes@npm:5.0.1"
@@ -8472,7 +8835,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0":
+"semver@npm:2 || 3 || 4 || 5, semver@npm:^5.5.0, semver@npm:^5.6.0":
   version: 5.7.1
   resolution: "semver@npm:5.7.1"
   bin:
@@ -8919,6 +9282,13 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
+  languageName: node
+  linkType: hard
+
+"stoppable@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "stoppable@npm:1.1.0"
+  checksum: 63104fcbdece130bc4906fd982061e763d2ef48065ed1ab29895e5ad00552c625f8a4c50c9cd2e3bfa805c8a2c3bfdda0f07c5ae39694bd2d5cb0bee1618d1e9
   languageName: node
   linkType: hard
 
@@ -9434,7 +9804,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.3.1":
+"tslib@npm:^2.2.0, tslib@npm:^2.3.1":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
@@ -9485,6 +9855,13 @@ __metadata:
   peerDependencies:
     typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
   checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
+  languageName: node
+  linkType: hard
+
+"tunnel@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: c362948df9ad34b649b5585e54ce2838fa583aa3037091aaed66793c65b423a264e5229f0d7e9a95513a795ac2bd4cb72cda7e89a74313f182c1e9ae0b0994fa
   languageName: node
   linkType: hard
 
@@ -9983,6 +10360,23 @@ __metadata:
   version: 3.0.0
   resolution: "xml-name-validator@npm:3.0.0"
   checksum: b3ac459afed783c285bb98e4960bd1f3ba12754fd4f2320efa0f9181ca28928c53cc75ca660d15d205e81f92304419afe94c531c7cfb3e0649aa6d140d53ecb0
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:^0.4.19":
+  version: 0.4.23
+  resolution: "xml2js@npm:0.4.23"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: ca0cf2dfbf6deeaae878a891c8fbc0db6fd04398087084edf143cdc83d0509ad0fe199b890f62f39c4415cf60268a27a6aed0d343f0658f8779bd7add690fa98
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,49 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@apoyo/files-s3@workspace:packages/files-s3":
+  version: 0.0.0-use.local
+  resolution: "@apoyo/files-s3@workspace:packages/files-s3"
+  dependencies:
+    "@apoyo/files": 0.0.1
+    "@aws-sdk/client-s3": ^3.161.0
+    "@aws-sdk/lib-storage": ^3.161.0
+    "@aws-sdk/s3-request-presigner": ^3.161.0
+    "@types/jest": ^26.0.23
+    "@types/node": ^14.18.21
+    get-stream: ^6.0.1
+    jest: ^26.4.2
+    ts-jest: ^26.3.0
+    ts-node: ^8.0.2
+    tsup: ^6.1.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@apoyo/files": 0.0.1
+  languageName: unknown
+  linkType: soft
+
+"@apoyo/files@0.0.1, @apoyo/files@workspace:packages/files":
+  version: 0.0.0-use.local
+  resolution: "@apoyo/files@workspace:packages/files"
+  dependencies:
+    "@apoyo/std": "workspace:^"
+    "@types/etag": ^1.8.1
+    "@types/fs-extra": ^9.0.13
+    "@types/jest": ^26.0.23
+    "@types/node": ^14.18.21
+    etag: ^1.8.1
+    fs-extra: ^10.1.0
+    jest: ^26.4.2
+    memfs: ^3.4.7
+    ts-jest: ^26.3.0
+    ts-node: ^8.0.2
+    tsup: ^6.1.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@apoyo/std": "workspace:^"
+  languageName: unknown
+  linkType: soft
+
 "@apoyo/http@^0.0.6, @apoyo/http@workspace:packages/http":
   version: 0.0.0-use.local
   resolution: "@apoyo/http@workspace:packages/http"
@@ -141,7 +184,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apoyo/std@^0.0.15, @apoyo/std@workspace:packages/std":
+"@apoyo/std@^0.0.15, @apoyo/std@workspace:^, @apoyo/std@workspace:packages/std":
   version: 0.0.0-use.local
   resolution: "@apoyo/std@workspace:packages/std"
   dependencies:
@@ -154,6 +197,1124 @@ __metadata:
     typescript: ^4.7.4
   languageName: unknown
   linkType: soft
+
+"@aws-crypto/crc32@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/crc32@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: 88ab906da8304a430c655496e363835f3c7ca870db0dec50bb9d53ed0f446337de60c85ba7baa4528c8363bee708474785649262ebfde23a1e099eb69318b53e
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/crc32c@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/crc32c@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: 776e1e61b3bde018b815d3973774a4ec3cd88c282046e49bb5a2625ac7db923068aad708a8e4c21b62a80e50a5c58324a32621b9ba82b7b2ecab66370c4fe893
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/ie11-detection@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/ie11-detection@npm:2.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: dd15daa1160ecdf28b9c930dcbd7f8bc96e74d7f791134974b672f5d36182274c76db4fff414385cdb8997a8b7ade991988a571aaac3184e226e2ed6428d895f
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha1-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha1-browser@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 72c0b24800cd79328fef934553e7a5d5929c90877d7e9a661614542dd29d0d99ee1594bd59fc028ee9ec595d77df56645a396c6336cff3c7784a564302d4a254
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-browser@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-browser@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/ie11-detection": ^2.0.0
+    "@aws-crypto/sha256-js": ^2.0.0
+    "@aws-crypto/supports-web-crypto": ^2.0.0
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-locate-window": ^3.0.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 7bc1ff042d0c53a46c0fc3824bd97fb3ed1df7dc030b8a995889471052860b8c8ade469c97866fafd8249a3144d0f48b0f1054f357e2b403606009381c4b8f0e
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/sha256-js@npm:2.0.0"
+  dependencies:
+    "@aws-crypto/util": ^2.0.0
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: e4abf9baec6bed19d380f92a999a41ac5bdd8890dfd45971d29054c298854c5b7087e7de633413f2e64618ef8238ccf4c0b75797c73063c74bbba3cb5d8b2581
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/sha256-js@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "@aws-crypto/sha256-js@npm:2.0.1"
+  dependencies:
+    "@aws-crypto/util": ^2.0.1
+    "@aws-sdk/types": ^3.1.0
+    tslib: ^1.11.1
+  checksum: d5f07a5dde2cde277b63e781adc3fb0d04e202f56d159b50089f3bfd8bf657db1c35e18813e2ec6c3771dfdf0d0d6eb13f36a8ad021b5db7d2bb8fdc9f06dce3
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/supports-web-crypto@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@aws-crypto/supports-web-crypto@npm:2.0.0"
+  dependencies:
+    tslib: ^1.11.1
+  checksum: 77fad3813a5d3c495296fb836293184d32aeddacd436bf7d1b59b93d87de4cf7c0dbf862d4eaf915259edfb7b424ea05e2ceeddbaa1588a154d0c19df455c475
+  languageName: node
+  linkType: hard
+
+"@aws-crypto/util@npm:^2.0.0, @aws-crypto/util@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@aws-crypto/util@npm:2.0.1"
+  dependencies:
+    "@aws-sdk/types": ^3.1.0
+    "@aws-sdk/util-utf8-browser": ^3.0.0
+    tslib: ^1.11.1
+  checksum: 83d7edea95336869854eb98bf53416a70ee824a03c8858779abcef7b7f35813ba3ba0aaa571d87c416bdcec78b620e825fe9e65769a15d2009af0ccb279ef981
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/abort-controller@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/abort-controller@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 6ea2d7ab2daa40f252d4aa5178b30536f2c3fcf4ba30e03025df50350b52388bf343e870d5581d44e0af52933906f3b9f57c05d63eb379621825d53752b19c6d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/chunked-blob-reader-native@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/chunked-blob-reader-native@npm:3.109.0"
+  dependencies:
+    "@aws-sdk/util-base64-browser": 3.109.0
+    tslib: ^2.3.1
+  checksum: fd6b0f5abd0577d403dd28ef98d065a1c0b15b342c050b90d51812d9f2e7a94da63e16cd7c279145badd1b576a66b39c2c3d90a6b9babd1a906db7f4776e53e8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/chunked-blob-reader@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/chunked-blob-reader@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 2e8794b7dad0075bb651241b0f10980fb9ca6556e9be14a7f35c4add17928c25eae3b7fa61fa868b2378447d886b3a0e150ef322629ff2b118c3bdc1b47328ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/client-s3@npm:3.161.0"
+  dependencies:
+    "@aws-crypto/sha1-browser": 2.0.0
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/client-sts": 3.161.0
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-node": 3.161.0
+    "@aws-sdk/eventstream-serde-browser": 3.160.0
+    "@aws-sdk/eventstream-serde-config-resolver": 3.160.0
+    "@aws-sdk/eventstream-serde-node": 3.160.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-blob-browser": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/hash-stream-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/md5-js": 3.160.0
+    "@aws-sdk/middleware-bucket-endpoint": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-expect-continue": 3.160.0
+    "@aws-sdk/middleware-flexible-checksums": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-location-constraint": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-sdk-s3": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/middleware-ssec": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4-multi-region": 3.160.0
+    "@aws-sdk/smithy-client": 3.161.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.161.0
+    "@aws-sdk/util-defaults-mode-node": 3.161.0
+    "@aws-sdk/util-stream-browser": 3.160.0
+    "@aws-sdk/util-stream-node": 3.160.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    "@aws-sdk/util-waiter": 3.160.0
+    "@aws-sdk/xml-builder": 3.142.0
+    entities: 2.2.0
+    fast-xml-parser: 3.19.0
+    tslib: ^2.3.1
+  checksum: 9b192690fe9fe8c912d4132f073e6c73ba391be59df4c749a964c80259f62647da48657c181c3b58fcf579e0047676acf6faef239218b189a81d7d2ef4321297
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sso@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/client-sso@npm:3.161.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/smithy-client": 3.161.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.161.0
+    "@aws-sdk/util-defaults-mode-node": 3.161.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 44461754e2bfd63ca175272e46960ecfb6be778e787188967dea4779643a19282967cb0015716da6d78bf3ff8cfeaa0b674b5ce82d3dbe128e387f208912cff0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-sts@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/client-sts@npm:3.161.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 2.0.0
+    "@aws-crypto/sha256-js": 2.0.0
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-node": 3.161.0
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/hash-node": 3.160.0
+    "@aws-sdk/invalid-dependency": 3.160.0
+    "@aws-sdk/middleware-content-length": 3.160.0
+    "@aws-sdk/middleware-host-header": 3.160.0
+    "@aws-sdk/middleware-logger": 3.160.0
+    "@aws-sdk/middleware-recursion-detection": 3.160.0
+    "@aws-sdk/middleware-retry": 3.160.0
+    "@aws-sdk/middleware-sdk-sts": 3.160.0
+    "@aws-sdk/middleware-serde": 3.160.0
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/middleware-user-agent": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/smithy-client": 3.161.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-base64-node": 3.55.0
+    "@aws-sdk/util-body-length-browser": 3.154.0
+    "@aws-sdk/util-body-length-node": 3.55.0
+    "@aws-sdk/util-defaults-mode-browser": 3.161.0
+    "@aws-sdk/util-defaults-mode-node": 3.161.0
+    "@aws-sdk/util-user-agent-browser": 3.160.0
+    "@aws-sdk/util-user-agent-node": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    entities: 2.2.0
+    fast-xml-parser: 3.19.0
+    tslib: ^2.3.1
+  checksum: ce18618c7286952b08d7af469416127293626c33c6c415345b0154c4f2ed4e59ac832c7a40279fa6d1eb9bfff1a68d9f498cfe208f5da22d0fc9b49eae1d81b7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/config-resolver@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/config-resolver@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-config-provider": 3.109.0
+    "@aws-sdk/util-middleware": 3.160.0
+    tslib: ^2.3.1
+  checksum: a707723eca6df17ff051b7bfdb47498febac2075c3cea8b7136b9c2987c210a5b8d119f57e5ef20341a6b2021a8f04681f981a7755ee48d35cef02cb2b51562a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2ef83c94033db48a89e2353ae7309f1c7e14b86bf5723b1b2309fca278ad1507447e39a100e9a3c8a90cc0530ca3b295a922773d84d7bcefb399f117715bc50e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-imds@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-imds@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/url-parser": 3.160.0
+    tslib: ^2.3.1
+  checksum: 1227a85e1fede3cd65168e567c300e9d3e6a89578fe12c2e9d7ea734310fe9cc9cecb766b2e6770bbb784f573d450d0123d764b21922ed80ba6d96df49b29ebc
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/credential-provider-sso": 3.161.0
+    "@aws-sdk/credential-provider-web-identity": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 3deb852e4d2772da7de0e2de5e52d79a0836d3a0d7df8c582cbf054401691b8fd52b9298a02d4a2c5562c7e69a4ef7a08b20317f8d69448680b2b650fd038b77
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/credential-provider-env": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/credential-provider-ini": 3.161.0
+    "@aws-sdk/credential-provider-process": 3.160.0
+    "@aws-sdk/credential-provider-sso": 3.161.0
+    "@aws-sdk/credential-provider-web-identity": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: fe7ab9a7a461ece52ab0dbef4693ac187f2efc7f32de6e28b6889683624e253675aa0df02461b21f99a16837a52725b91e4d32aa5616cb778681d0ae55d2993a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2157f4eb335f63b9f837775ee28ae755a4d2cca268e3ed29efcb0d59b14e9a428355afc290643a1a5b4c81a8ca1296e7efab912fb4bcd21cb157608b10a1153a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/client-sso": 3.161.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2d13fe21a92008203f5310d1b72a2d77bd0b9fd1be216d2df018f2a0f508c95ffc970ac08189d86100ba2cb1617cc3120e1b83a02205170edc396ad0110c03a9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: ef6b12cf7936649277b8d89539c633ae0c3dcba9a1f4b2a8955d1a81a1ca32761f6f85933b14defa335ec7bf6f9eeba0782966bd0b7fcbc303bcc52013da5e78
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-codec@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/eventstream-codec@npm:3.160.0"
+  dependencies:
+    "@aws-crypto/crc32": 2.0.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-hex-encoding": 3.109.0
+    tslib: ^2.3.1
+  checksum: 1144684aa258176a02d406216a7eda5a3d436a7f83a1d3a28235de62e2cc543005123d87be3ca9806449c73a9b8005050194b8149c1b5de0ffb0e8279c8ee730
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/eventstream-serde-browser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: b228f7033d9752849ab0a07c4eb944ebbb230216c319763f4a9f6068f804e7a23698cda0ca3e44f9d3fc1236d6573ff9b65f1d3d9b56035cdea4089366ab6f39
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-config-resolver@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/eventstream-serde-config-resolver@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 8ff9ad970569d0e5705241deadd4fb413172e674f0486c5a75c508a22481c1295f2d6cc7b3277032653d9365be7b65e19ff77f89df025df0a41eaa290a247f43
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/eventstream-serde-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/eventstream-serde-universal": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: dd56ee010d548b76b61a24b843554174042158503e6d167d6777ba9a164c6409ea3d795dafcbeba4f30da7facca1b0f88c545e336b9cb65ed319752747a0b4a1
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/eventstream-serde-universal@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/eventstream-serde-universal@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/eventstream-codec": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: cff486f09ca818eb63e5013412cd2981505321bc2caa205d93a2eb3d358eb7186075cbf95dea7190e91141481a6057ade17ea484667146ad88fe5ccfd5ebe10b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/fetch-http-handler@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/fetch-http-handler@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/querystring-builder": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    tslib: ^2.3.1
+  checksum: 14b509317b6881d87854b7417e1cbb3645d5745d08e1600c6107963946f669394047c4d41dd829fdaf6b5a843415817419e29b7c67643fc195c1390f4c3f26d3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-blob-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/hash-blob-browser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/chunked-blob-reader": 3.55.0
+    "@aws-sdk/chunked-blob-reader-native": 3.109.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: ec12cf7e26e0e4211d320af4e78ab9cf4bfab02679686b2063403d0258c94623665534a63132a455baf606b31e7e102c01332cd093d65aec4e4a561b1b620180
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/hash-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: 5384b46e33d0685aa0957bcb68729e3537b6b6adbc87b6c3facd50ecc40313d90c76145e46bfbdc702cc5aa209b6d5405f2789017646ff0fa74ef182400edbef
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/hash-stream-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/hash-stream-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 3bf3163df30842536587586224c6606b87e507c860ec21c1925c214af2eb3bbe8d41a4984a1420e991f74afaf05964a0fa77aa6da07030d848f55d63f48cc8c4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/invalid-dependency@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/invalid-dependency@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 499b9a20094f0e16510aa9f07aaa2d4515f0a63214ec7a9b6abcafb021d26f14464b99faf392a03150ebb8cf5fdedafbcb78d42d43f1f1eeb989ccc10d155b43
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/is-array-buffer@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/is-array-buffer@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 527481f024166197b84a2b4859b51df9b6da4396255c19832e8fdb2f6dfc914dab8ad89433602f8d797f3f8dacc312ab8a0073b2c8e20dc85a28ad9d27aceaa7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/lib-storage@npm:^3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/lib-storage@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/smithy-client": 3.161.0
+    buffer: 5.6.0
+    events: 3.3.0
+    stream-browserify: 3.0.0
+    tslib: ^2.3.1
+  peerDependencies:
+    "@aws-sdk/abort-controller": ^3.0.0
+    "@aws-sdk/client-s3": ^3.0.0
+  checksum: 41c280a30a1c5cf39f1161f8751309c864f9a9f389d8ebea34552e5bee7ef00747f18a6f5ed8885cf445427444b0d4ebd04c4b900705def44d28989ac10ed309
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/md5-js@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/md5-js@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    "@aws-sdk/util-utf8-node": 3.109.0
+    tslib: ^2.3.1
+  checksum: 34197cebb03eb61127ae50b74d94efb86f67228ef74de674ef68cf77e1bd569f3ad365275af8f2e94cf1755b17f37e03370738971f8674aa42ff594b9108ff86
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-bucket-endpoint@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-arn-parser": 3.55.0
+    "@aws-sdk/util-config-provider": 3.109.0
+    tslib: ^2.3.1
+  checksum: 837c49857b38569f7bad38f580988f5cc5c371144697e08f6d6ea9c51893c08d5d3d6ba9a4d6beda32cabd858bd56c85c2a5e8b8244e48cf31865d859f6ca5f0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-content-length@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-content-length@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9160b44ced03c7f95da2461b88bfb219147245cea5739c84c377e01711329b7ad4aacda0ae2f9f947efad55fe419a4990d6dd8552ae4d5d84f93d368fd7ba76f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-expect-continue@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-expect-continue@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 091ecdb06743ce66b0dcbad5c410f93997fbe66c59c3f64121cb7c0ad9d0b89f9bf814d57a881d709f3c5517bca5baf584a00a2e54d1bbf2991549999ffa2da0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-flexible-checksums@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.160.0"
+  dependencies:
+    "@aws-crypto/crc32": 2.0.0
+    "@aws-crypto/crc32c": 2.0.0
+    "@aws-sdk/is-array-buffer": 3.55.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 18b6ff4630b6091c37b3c6d28172af0f50aec880241360136d087ab431a72cca5c56aab884971c2a9663f85f096c5a54373c75b45d5d1f2b275e1f7253b19b50
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-host-header@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-host-header@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9be84716aa20f6ccb57fbfc3c3b1e39fa5c3335624050a7012d800e92420b997f3d5cf44bfb6536cab13f473a3c3acdc16340314943bb2eb004867849acc26b4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-location-constraint@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-location-constraint@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 447f0a9d33a68e14be7fba94235903315db8e24b7ee31d8c765174286a31e8e5ebaac35b263a39a5a2cb820b3250c57365cda0d293c35b7932f33de1f5e664db
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-logger@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-logger@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 20f6e732651377946520cc0a9141d08876d0f710635f05be5afd82a42751c4d63b20088dff0fae3ab38f3e7b9b26eec55b1548c94edb19a4223a7cee5e75de52
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-recursion-detection@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-recursion-detection@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 7b162d36a10d4a28b41ac47dbb2bacbfa0900f9762e9ed1728a0965ed9ad176ef6dc4914098c01a19b547157355486a11a6d1be91455054baf1fcf234a4b3e05
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-retry@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-retry@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/service-error-classification": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-middleware": 3.160.0
+    tslib: ^2.3.1
+    uuid: ^8.3.2
+  checksum: 5927a238e104d59b5b15a38256ef5e4e4d9ae10b1d0cef1f471bcc7505802045e44de375672b8dd0326cc1b18bf4bc7cb9290e9cc4a2a5eb344a78a87d04c7a2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/middleware-bucket-endpoint": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-arn-parser": 3.55.0
+    tslib: ^2.3.1
+  checksum: a10a4d865f84643f94e3697a883ec5c8bfa3302a980a9387d63dd58473178d4ae992ddd0cbf6589def8789fc3f4656c150553e12a257d1bc310f7059f7206bf5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-sts@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-sdk-sts@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/middleware-signing": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 53ad369ee80cba579896ed73793b0ecf40679cf264fdbec966036dd213cf0fbf92a2ce8195eb83241b3dad79338b775eaee886bfac309ef8934a4814670ee718
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-serde@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-serde@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 9daeddc2951d86f5fc3a22fb7b21db48cd8da28322967fda7bbddaf53535ae9b7a2330ce00418b1e20612ea7dfa3add2941465d854478fbb3ff5d628e481178a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-signing@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-signing@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 2a29454f0ee3410ede0c3a75dc77bb3f329031648b84df8439f5a229e0efee388e8efdb587264f48a02e6ae861c509bc8d5df487a976a4a2fd729c50c2e86164
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-ssec@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-ssec@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: de58bb38a772118a64ef512191bf452de26f78be51485ab51572c4f6e7fde399bb4f5e9fa02d01e9aa2504398607fa9d4c5fa182569af881228bad014a902f9b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-stack@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-stack@npm:3.160.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 37342fc5e98f8149575049eab8c4254f786cf6ff2f45eb9d0a96916814932a9f6dce4710ba23a8cb2c566f138230f376dfcd9dae50edc2b4427c44ee6156048d
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-user-agent@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: bba8ab69cc3088646b1a137f7b69b886b77cdd17d79e33922648fde29d9aadca08b23be305c6af4029cbc5b9b4cad35f4b3c939b591a7f9c40709a19816aee2a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-config-provider@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/node-config-provider@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/shared-ini-file-loader": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: f81c7d291f4e56c2232a5e37c7a090385be05e26a77e3b96ace410eff497df3993cda4ebed456420088b7fc90bf393cc36769b971fb92dcf12f98d5949259729
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/node-http-handler@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/node-http-handler@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/querystring-builder": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 5defd4da366205b29f696348a40b170e32d3893da8000459ef8748daa27834d931c0f729d53c74ed10cd8585318533daa02c9eacf9e918f16f8b15f8fb4d387c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/property-provider@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/property-provider@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 6eafa3e4867b40a018be0f8de7ad37eb0c7707260695734578353a7cfc1429df448b794aa89fb47d582f59650bd560e124016c43f9c72843779e2a66aa2c31a9
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/protocol-http@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/protocol-http@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 572cd4bb9e78c95d5dba3a4714c2b54607eebefd1c6deb9b5f0efd12b474c4bb0444b03adfe150a8ff94e3fd82e5c978b7116664e2694114c5a46978f7362b24
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-builder@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/querystring-builder@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: 94a008fbc4464de3e7b9d0c4e0562f6ef07064ba2a515c0051b7b54f3633a33887fb36b3382acbd7f20731f25c69d29deaefa9b8778b8b713d524ecc95f93f8c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/querystring-parser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/querystring-parser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: c5d8e5e965c26d2f8c701b98f3d797bba492683be0438fd358a25605914ad714b52aa108c9069cd34d2f25e96b17fc4ba3cd773e73a4fb8e904073f5dc59a6e3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/s3-request-presigner@npm:^3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/middleware-sdk-s3": 3.160.0
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4-multi-region": 3.160.0
+    "@aws-sdk/smithy-client": 3.161.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-create-request": 3.161.0
+    "@aws-sdk/util-format-url": 3.160.0
+    tslib: ^2.3.1
+  checksum: c40b5fe596a6203d67522035bb5dedfa39f11ebd67ab885e605ee23d76db734ded4d8d6885e483cb73538bf04304f4cb42dde6018f298d739884aa33670b9fd4
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/service-error-classification@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/service-error-classification@npm:3.160.0"
+  checksum: c459f532a814da7cb40d41fce0dc3cdacff0e0ced3d23ac045a934f99a23db7fdfe3a566611ec483c26eb6baaaaf1d7126e2d58fb84596d197aee378f91cc4b0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/shared-ini-file-loader@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/shared-ini-file-loader@npm:3.160.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 7b78d2d8b743e03c06a8a3281c15002df9b043de0a8c99b0bcaca2113f6d56166b5121b535e656833f1dfd45fcfea23e86575aebfad612c869b3e1f81764b8e3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/protocol-http": 3.160.0
+    "@aws-sdk/signature-v4": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-arn-parser": 3.55.0
+    tslib: ^2.3.1
+  peerDependencies:
+    "@aws-sdk/signature-v4-crt": ^3.118.0
+  peerDependenciesMeta:
+    "@aws-sdk/signature-v4-crt":
+      optional: true
+  checksum: b39c6342dfb5851dc1e02dabb59c22e439909f2161ce5d1f78c55b837a7af51d438afb157cb272a1f5e3fcf78e6868e27c534ab40d3dd6a61e3eff84dda7984b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/signature-v4@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.55.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-hex-encoding": 3.109.0
+    "@aws-sdk/util-middleware": 3.160.0
+    "@aws-sdk/util-uri-escape": 3.55.0
+    tslib: ^2.3.1
+  checksum: dabbbaa5e9ea51c58c62da0d4cc2de7cae1458b717501a444d17b45c10322c132fb2ab8bb8a322c4ce8a192ce0433901f58dc9a57380d1e5a152cd5c0cec9d0f
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/smithy-client@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/smithy-client@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: abde6ededfd82dabfa055c3a1848a2e7ee9fc769e121f58a41296f7c39495eff006624368467a907cc17555ae7cc1a1117e538ca0619e92c52cb5202965d7ce8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:3.160.0, @aws-sdk/types@npm:^3.1.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/types@npm:3.160.0"
+  checksum: f33abfdcd08745cfb9e0bd050f9c85228e9f0bea938c01b86875e232798473cb03394dd2846f37c5ddd087a1595613591722fa240c21bbfa1b3e8c1772d24d28
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/url-parser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/url-parser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/querystring-parser": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 1090b25cd0e7a9d77875745a4a3709f1e67f9ef8b8dd596f257ccf8567025d11ad76684f18c08f1f9148eb4aedabb5cfa5f441ba23a5631f913074f64a3b9d10
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-arn-parser@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-arn-parser@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: d98f38ef89c3d60a9ef4c7129338969f90c760817d8c0d8eaada19b09af1a033afcdade62cf1e990af1cab12c07bc2dff85fecae2fd1e8083e518d4a99a2b079
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64-browser@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-base64-browser@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: e4fb1dc0e5ac60320d4ba05dcf03b8e641c7a304f918df3134bf46c8ccf5b09d07ee283924a4cc4e9250fef582a2636bb4dac6ba71ee36662b2678dfe49d46b2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-base64-node@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-base64-node@npm:3.55.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: 4a2a58ae2e5d2d904271dd0433b9c15ca9a8e9d62e979c82159420ab8e1b573e96c8f223c951be2139cdfe49a09c478d165eff9468978883c4c5bcdfa7d9fd4b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-browser@npm:3.154.0":
+  version: 3.154.0
+  resolution: "@aws-sdk/util-body-length-browser@npm:3.154.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 8c8de55960f2d038bddf8748896bfb322f125cc04ec994fa6610a09fdb9d302817b610a08f76ab100ae682718214e5c2296b03913e11a156de93ca3c002a3143
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-body-length-node@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-body-length-node@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 35ae66271b7160c53b344a2bd933b5882e9fcef4a47c579a2a9e313657da8b896ca6c674489767f75d148ea5ffb8cbde2127eae55f5f39aaa4823a7c1d98ec69
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-buffer-from@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-buffer-from@npm:3.55.0"
+  dependencies:
+    "@aws-sdk/is-array-buffer": 3.55.0
+    tslib: ^2.3.1
+  checksum: 0c1d72cf2369c13a8bff7d990f8e8da7f5584dcbdf1965cf50674d531b42d80661eebdbbaf968d6932760fc3f5708374a676d05485a1d02347655ea5f2423f57
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-config-provider@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-config-provider@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 99c9ef24faa555a317b46b782e211474dd9d666611e1aa76b963e93a6e7c54e32d5c20b87d9a601b9de68dfa1c7310d72667a74c335b31edb776e8494e2541af
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-create-request@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/util-create-request@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/middleware-stack": 3.160.0
+    "@aws-sdk/smithy-client": 3.161.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: 65c8062fcd4529e28b1709a077cef9ef3302d28eaf6da9f61dd4b32fa8c6efaf871f411c9e8f6749e408e00c34c08af1295555de068441b5d7df9c567d2e21d0
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-browser@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/util-defaults-mode-browser@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: 1e0b0c1b82f9e9336b8e767de44e5a6da1eb413c88e035420c55bd1d683e5737058d23fcda859d59c5b8574a1bbb55d4f06a7ffd24504a7e0eeb422df4833d54
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-defaults-mode-node@npm:3.161.0":
+  version: 3.161.0
+  resolution: "@aws-sdk/util-defaults-mode-node@npm:3.161.0"
+  dependencies:
+    "@aws-sdk/config-resolver": 3.160.0
+    "@aws-sdk/credential-provider-imds": 3.160.0
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/property-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: ad9d0d06db33a32fcf60ab18381a24bd4f83cbc939aa8e4c9d7a795fdf6713e765b8ab13f1f579638ff6d3f086231b1f190a3e95e369d1c28c6c05b8893b633c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-format-url@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-format-url@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/querystring-builder": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: b72421820bcb6c45d11d97e160d68e9242f84839ed630e6a721c7edbe5381993bb69f35998cd3067d5726cabe259a59f622f58e935d8d696baa042989b491e74
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-hex-encoding@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-hex-encoding@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 1c166b53d7f84c0271cb71da8ac0ef4a9bfd78f2d2d70e4a903921dd3c355a79a446fa66ff64522d87aa9c738f445fdfd527043980bea642ae3acbc7dd758edf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-locate-window@npm:^3.0.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-locate-window@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 5bc79779a17ae4dd5cbcc221df6e85c976a149c0868745ae58075a3c51506aeeb087dfde4b3e5179004461243b11f3a458de720ee92866c6a1b65182326259ae
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-middleware@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-middleware@npm:3.160.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 92e4eb6f5338fe1105ec7556b7a6b67562392d1fd66be1b1478c0eb7797588881c60bdf458a0c9a20f64281f5c729b6dd0daa8b8bd92fbc95d21aeb85c67e0ee
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-stream-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-stream-browser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/fetch-http-handler": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-base64-browser": 3.109.0
+    "@aws-sdk/util-hex-encoding": 3.109.0
+    "@aws-sdk/util-utf8-browser": 3.109.0
+    tslib: ^2.3.1
+  checksum: 8d8a372e85ee4edf69596d4b4bb84754aa464e446b87a00eaee9aace8f16ca7ae1d0b981dd1465cd2feb6a3512bf4e20c716ac39031128400f8bd214d53ac472
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-stream-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-stream-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/node-http-handler": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: 9953325900f2ec52abda4d970be2ef3e13e8db21c98ccd89df7c43e7b3c977f5c865033211110aaa387c1eaa6c37acf8515361cf6d3ebceeed9ccd0d7b8c2416
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-uri-escape@npm:3.55.0":
+  version: 3.55.0
+  resolution: "@aws-sdk/util-uri-escape@npm:3.55.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: fad6780856f2b42a11ce7bb1e2ea5b7a966a8f564f3d09e83dca024291ae589a0cb2a1d294812cd626346addeb292c178f84867e40f8fab6fca067bc42ad360a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-browser@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-user-agent-browser@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/types": 3.160.0
+    bowser: ^2.11.0
+    tslib: ^2.3.1
+  checksum: 344ca03f2b1d4227643d12881408e1c6bbdb7fb5d5516ad39cb404b2c5ae71148e3e9f272f5f26e5de0a22e901dc75afcbb8102f275f9aa537b98289cc588ccf
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-user-agent-node@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/node-config-provider": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  peerDependencies:
+    aws-crt: ">=1.0.0"
+  peerDependenciesMeta:
+    aws-crt:
+      optional: true
+  checksum: 3ae0a51810ca2807f71341930899355f035694f70807b403548698ab3a24b16a55b8771a7d5bf9c80b1a97317ab26b2d14afebb0829454f8d0a15ced624c6eb5
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-browser@npm:3.109.0, @aws-sdk/util-utf8-browser@npm:^3.0.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-browser@npm:3.109.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: 8311763b04261dab5995ec67abf31795f41e9c4b1ad635ed305735e14c7e3bc48e9ae349a06aab485390358a6a58e97190144ea51190983cec4ae665887b219b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-utf8-node@npm:3.109.0":
+  version: 3.109.0
+  resolution: "@aws-sdk/util-utf8-node@npm:3.109.0"
+  dependencies:
+    "@aws-sdk/util-buffer-from": 3.55.0
+    tslib: ^2.3.1
+  checksum: ef706db8c0ceb014bc2fb9e5045b54369160648a9e919836132f98c5537eda82193f400fab607783ecf98a5df11b66c32256c4f2780bc689d7507ddaf2a0977b
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-waiter@npm:3.160.0":
+  version: 3.160.0
+  resolution: "@aws-sdk/util-waiter@npm:3.160.0"
+  dependencies:
+    "@aws-sdk/abort-controller": 3.160.0
+    "@aws-sdk/types": 3.160.0
+    tslib: ^2.3.1
+  checksum: d93d655324ea4acdba9224b0090c60ec9cbafd3e26cc85c0495669fd1c449548f0a9e8a144392ca46aa407225f59ad158e675875f1a4db5cae964906f7f912c3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:3.142.0":
+  version: 3.142.0
+  resolution: "@aws-sdk/xml-builder@npm:3.142.0"
+  dependencies:
+    tslib: ^2.3.1
+  checksum: ea2feb6b9e6af58aa63dd1c66d9101cc6e4e5102a730246ccd3cd19ee480147ecca3f41c93d3b9fcfcbf0b9b4e9086dc275806fbcdda24d6f7193814ffc2d02c
+  languageName: node
+  linkType: hard
 
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.16.7":
   version: 7.16.7
@@ -1078,6 +2239,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/etag@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@types/etag@npm:1.8.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 93ae9d2eeeee484b9a9edc46581c6d9f32163b61f3f9a8c3df3a9ef903d1efc9c8e5b9146b10c19f3d1f23d40419426cb85eea20cf42cfaa1af3abda2d405cee
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:^4.17.18":
   version: 4.17.28
   resolution: "@types/express-serve-static-core@npm:4.17.28"
@@ -1098,6 +2268,15 @@ __metadata:
     "@types/qs": "*"
     "@types/serve-static": "*"
   checksum: 12a2a0e6c4b993fc0854bec665906788aea0d8ee4392389d7a98a5de1eefdd33c9e1e40a91f3afd274011119c506f7b4126acb97fae62ae20b654974d44cba12
+  languageName: node
+  linkType: hard
+
+"@types/fs-extra@npm:^9.0.13":
+  version: 9.0.13
+  resolution: "@types/fs-extra@npm:9.0.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: add79e212acd5ac76b97b9045834e03a7996aef60a814185e0459088fd290519a3c1620865d588fa36c4498bf614210d2a703af5cf80aa1dbc125db78f6edac3
   languageName: node
   linkType: hard
 
@@ -1833,7 +3012,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.0.2, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -1888,6 +3067,13 @@ __metadata:
     raw-body: 2.4.3
     type-is: ~1.6.18
   checksum: 7f777ea65670e2622ca4a785b5dcb2a68451b3bb8d4d0f41091d307d56b640dba588a9ae04d85dda2cdd5e42788266a783528d5417e5643720fd611fd52522e7
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.11.0
+  resolution: "bowser@npm:2.11.0"
+  checksum: 29c3f01f22e703fa6644fc3b684307442df4240b6e10f6cfe1b61c6ca5721073189ca97cdeedb376081148c8518e33b1d818a57f781d70b0b70e1f31fb48814f
   languageName: node
   linkType: hard
 
@@ -1981,6 +3167,16 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 0448524a562b37d4d7ed9efd91685a5b77a50672c556ea254ac9a6d30e3403a517d8981f10e565db24e8339413b43c97ca2951f10e399c6125a0d8911f5679bb
+  languageName: node
+  linkType: hard
+
+"buffer@npm:5.6.0":
+  version: 5.6.0
+  resolution: "buffer@npm:5.6.0"
+  dependencies:
+    base64-js: ^1.0.2
+    ieee754: ^1.1.4
+  checksum: d659494c5032dd39d03d2912e64179cc44c6340e7e9d1f68d3840e7ab4559989fbce92b4950174593c38d05268224235ba404f0878775cab2a616b6dcad9c23e
   languageName: node
   linkType: hard
 
@@ -2820,6 +4016,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:2.2.0":
+  version: 2.2.0
+  resolution: "entities@npm:2.2.0"
+  checksum: 19010dacaf0912c895ea262b4f6128574f9ccf8d4b3b65c7e8334ad0079b3706376360e28d8843ff50a78aabcb8f08f0a32dbfacdc77e47ed77ca08b713669b3
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -3284,7 +4487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 571aeb3dbe0f2bbd4e4fadbdb44f325fc75335cd5f6f6b6a091e6a06a9f25ed5392f0863c5442acb0646787446e816f13cbfc6edce5b07658541dff573cab1ff
@@ -3295,6 +4498,13 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 1ffe3bb22a6d51bdeb6bf6f7cf97d2ff4a74b017ad12284cc9e6a279e727dc30a5de6bb613e5596ff4dc3e517841339ad09a7eec44266eccb1aa201a30448166
+  languageName: node
+  linkType: hard
+
+"events@npm:3.3.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
   languageName: node
   linkType: hard
 
@@ -3542,6 +4752,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:3.19.0":
+  version: 3.19.0
+  resolution: "fast-xml-parser@npm:3.19.0"
+  bin:
+    xml2js: cli.js
+  checksum: d9da9145f73d90c05ee2746d80c78eca4da0249dea8c81ea8f1a6e1245e62988ed4a040dbd1c7229b1e0bdcbf69d33c882e0ac337d10c7eedb159a4dc9779327
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.13.0
   resolution: "fastq@npm:1.13.0"
@@ -3710,12 +4929,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "fs-extra@npm:10.1.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
+  languageName: node
+  linkType: hard
+
 "fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
     minipass: ^3.0.0
   checksum: 1b8d128dae2ac6cc94230cc5ead341ba3e0efaef82dab46a33d171c044caaa6ca001364178d42069b2809c35a1c3c35079a32107c770e9ffab3901b59af8c8b1
+  languageName: node
+  linkType: hard
+
+"fs-monkey@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "fs-monkey@npm:1.0.3"
+  checksum: cf50804833f9b88a476911ae911fe50f61a98d986df52f890bd97e7262796d023698cb2309fa9b74fdd8974f04315b648748a0a8ee059e7d5257b293bfc409c0
   languageName: node
   linkType: hard
 
@@ -3942,17 +5179,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.6":
+  version: 4.2.10
+  resolution: "graceful-fs@npm:4.2.10"
+  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
+  languageName: node
+  linkType: hard
+
 "graceful-fs@npm:^4.2.4":
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: 68ea4e07ff2c041ada184f9278b830375f8e0b75154e3f080af6b70f66172fabb4108d19b3863a96b53fc068a310b9b6493d86d1291acc5f3861eb4b79d26ad6
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.2.6":
-  version: 4.2.10
-  resolution: "graceful-fs@npm:4.2.10"
-  checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
   languageName: node
   linkType: hard
 
@@ -4197,7 +5434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ieee754@npm:^1.1.13":
+"ieee754@npm:^1.1.13, ieee754@npm:^1.1.4":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
   checksum: 5144c0c9815e54ada181d80a0b810221a253562422e7c6c3a60b1901154184f49326ec239d618c416c1c5945a2e197107aee8d986a3dd836b53dffefd99b5e7e
@@ -4264,7 +5501,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -5211,6 +6448,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonfile@npm:^6.0.1":
+  version: 6.1.0
+  resolution: "jsonfile@npm:6.1.0"
+  dependencies:
+    graceful-fs: ^4.1.6
+    universalify: ^2.0.0
+  dependenciesMeta:
+    graceful-fs:
+      optional: true
+  checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^3.0.2, kind-of@npm:^3.0.3, kind-of@npm:^3.2.0":
   version: 3.2.2
   resolution: "kind-of@npm:3.2.2"
@@ -5499,6 +6749,15 @@ __metadata:
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
   checksum: af1b38516c28ec95d6b0826f6c8f276c58aec391f76be42aa07646b4e39d317723e869700933ca6995b056db4b09a78c92d5440dc23657e6764be5d28874bba1
+  languageName: node
+  linkType: hard
+
+"memfs@npm:^3.4.7":
+  version: 3.4.7
+  resolution: "memfs@npm:3.4.7"
+  dependencies:
+    fs-monkey: ^1.0.3
+  checksum: fab88266dc576dc4999e38bdf531d703fb798affac2e0dd3fc17470878486844027b2766008ba80c0103b443f52cf9068a5c00f4e1ecf04106f4b29c11855822
   languageName: node
   linkType: hard
 
@@ -6597,7 +7856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.0
   resolution: "readable-stream@npm:3.6.0"
   dependencies:
@@ -7351,6 +8610,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stream-browserify@npm:3.0.0":
+  version: 3.0.0
+  resolution: "stream-browserify@npm:3.0.0"
+  dependencies:
+    inherits: ~2.0.4
+    readable-stream: ^3.5.0
+  checksum: 4c47ef64d6f03815a9ca3874e2319805e8e8a85f3550776c47ce523b6f4c6cd57f40e46ec6a9ab8ad260fde61863c2718f250d3bedb3fe9052444eb9abfd9921
+  languageName: node
+  linkType: hard
+
 "string-argv@npm:^0.3.1":
   version: 0.3.1
   resolution: "string-argv@npm:0.3.1"
@@ -7796,7 +9065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^1.8.1":
+"tslib@npm:^1.11.1, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
@@ -7807,6 +9076,13 @@ __metadata:
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
   checksum: de17a98d4614481f7fcb5cd53ffc1aaf8654313be0291e1bfaee4b4bb31a20494b7d218ff2e15017883e8ea9626599b3b0e0229c18383ba9dce89da2adf15cb9
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.1":
+  version: 2.4.0
+  resolution: "tslib@npm:2.4.0"
+  checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
   languageName: node
   linkType: hard
 
@@ -7986,6 +9262,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"universalify@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "universalify@npm:2.0.0"
+  checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
+  languageName: node
+  linkType: hard
+
 "unpipe@npm:1.0.0, unpipe@npm:~1.0.0":
   version: 1.0.0
   resolution: "unpipe@npm:1.0.0"
@@ -8040,7 +9323,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.0":
+"uuid@npm:^8.3.0, uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:


### PR DESCRIPTION
**Features**:

Add framework agnostic file drivers matching a same contract. These file drivers are based on the Adonisjs Drive:
- `FakeDriver` (Memory file system) ported from Adonisjs
- `LocalDriver` (Local file system) ported from Adonisjs
- `S3Driver` (S3 file system) ported from Adonisjs
- `GCSDriver` (GCS file system) ported from Adonisjs
- `AzureDriver` (Azure Storage file system) ported from https://github.com/AlexanderYW/Adonis-Drive-Azure-Storage

**Todos**:

- Add tests for S3, GCS and Azure drivers