### PR TITLE
feat(files)!: rename interfaces and drivers

### DIFF
--- a/docs/vuepress/guide/files/driver-contract.md
+++ b/docs/vuepress/guide/files/driver-contract.md
@@ -1,9 +1,9 @@
-# Driver contract
+# Drive contract
 
-All drivers of this library implement the `DriverContract` interface, and as such, have access to all methods specified below by the contract:
+All drives of this library implement the `Drive` interface, and as such, have access to all methods specified below by the contract:
 
 ```ts
-export interface DriverContract {
+export interface Drive {
   /**
    * A boolean to find if the location path exists or not
    */

--- a/docs/vuepress/guide/files/examples.md
+++ b/docs/vuepress/guide/files/examples.md
@@ -1,34 +1,33 @@
 # Examples
 
-Create a new driver instance:
+Create a new drive instance:
 
 ```ts
-import { DriverContract, LocalDriver, FakeDriver } from '@apoyo/files'
-import { S3Driver } from '@apoyo/files-s3'
+import { Drive, LocalDrive, FakeDrive } from '@apoyo/files'
+import { S3Drive } from '@apoyo/files-s3'
 
-// Instantiate the driver you want to use (LocalDriver, FakeDriver, S3Driver or any other available driver)
-const driver: DriverContract = new S3Driver({
+// Instantiate the drive you want to use (LocalDrive, FakeDrive, S3Drive or any other available drive)
+const drive: Drive = new S3Drive({
   bucket: 'my-bucket',
   key: '<aws access key>'
   secret: '<aws secret key>'
 })
-
 ```
 
 **Simple usage:**
 
 ```ts
 // Write data to a file
-await driver.put('foo.txt', 'hello world')
+await drive.put('foo.txt', 'hello world')
 
 // Check if file exists
-const exists = await driver.exists('foo.txt') // is now true
+const exists = await drive.exists('foo.txt') // is now true
 
 // Move file
-await driver.move('foo.txt', 'bar.txt')
+await drive.move('foo.txt', 'bar.txt')
 
 // Delete file
-await driver.delete('bar.txt')
+await drive.delete('bar.txt')
 ```
 
 **Get file with stream:**
@@ -41,7 +40,7 @@ import { promisify } from 'util'
 const pipelineAsync = promisify(pipeline);
 
 // Get readable stream
-const readable = await driver.getStream('input.txt')
+const readable = await drive.getStream('input.txt')
 
 // Get writable stream
 const writable = await fs.createWriteStream("output.txt");
@@ -61,7 +60,7 @@ await pipelineAsync(
 ```ts
 const stream = fs.createReadStream('path/to/my-huge-archive.tar.gz').pipe(gunzipStream);
 
-await driver.putStream('my-huge-archive.tar', stream)
+await drive.putStream('my-huge-archive.tar', stream)
 ```
 
 **Note**: If you wish to track the progress of your stream, you will need to use 3rd party libraries, such as <https://www.npmjs.com/package/progress-stream>.

--- a/docs/vuepress/guide/files/getting-started.md
+++ b/docs/vuepress/guide/files/getting-started.md
@@ -1,29 +1,29 @@
 # Getting started
 
-This library is a simplified and framework agnostic version of [Adonisjs Drive](https://github.com/adonisjs/drive).
+This library is a simplified and framework agnostic version of [Adonis Drive](https://github.com/adonisjs/drive).
 
-As such, the API, as well as the source code, will be (and will probably stay) very similar to the `Drive` object of the `Adonisjs` framework.
+As such, the API, as well as the source code, will be (and will probably stay) similar to the `Drive` object of the `Adonisjs` framework.
 
 However, additional features and methods may be added later if required.
 
 Here a small usage example:
 
 ```ts
-import { FakeDriver } from '@apoyo/files'
+import { FakeDrive } from '@apoyo/files'
 
-const driver = new FakeDriver({})
+const drive = new FakeDrive({})
 
 // Write a file
-await driver.put(filePath, stringOrBuffer)
-await driver.putStream(filePath, readableStream)
+await drive.put(filePath, stringOrBuffer)
+await drive.putStream(filePath, readableStream)
 
 // Read a file
-const contents = await driver.get(filePath)
-const readableStream = await driver.getStream(filePath)
+const contents = await drive.get(filePath)
+const readableStream = await drive.getStream(filePath)
 
 // Find if a file exists
-if (await driver.exists(filePath)) {
-  await driver.get(filePath)
+if (await drive.exists(filePath)) {
+  await drive.get(filePath)
 }
 ```
 
@@ -31,105 +31,105 @@ if (await driver.exists(filePath)) {
 
 The primary goal of this library is to provide a consistent API that works across all the storage providers. So, for example, you can use the local file system during development and switch to S3 in production without changing a single line of code.
 
-To guarantee a consistent API, the drivers cannot work with the specifics of a given storage service.
+To guarantee a consistent API, the drives cannot work with the specifics of a given storage service.
 
-For example, you cannot create symlinks with the supported drivers since symlinks are a Unix-based file systems concept and cannot be replicated with S3 or GCS.
+For example, you cannot create symlinks with the supported drives since symlinks are a Unix-based file systems concept and cannot be replicated with S3 or GCS.
 
-Similarly, the proprietary features of a cloud service that cannot be replicated across drivers are also not supported.
+Similarly, the proprietary features of a cloud service that cannot be replicated across all drives are also not supported.
 
 ## Use cases
 
-The primary use case for these drivers is to help you quickly manage user-uploaded files. These can be user avatars, blog post cover images, or any other runtime managed documents.
+The primary use case for these drives is to help you quickly manage user-uploaded files. These can be user avatars, blog post cover images, or any other runtime managed documents.
 
 ## Installation
 
-All drivers will require the following peer dependencies:
+All drives will require the following peer dependencies:
 
 ```sh
 npm install @apoyo/files @apoyo/std
 ```
 
-## Supported drivers
+## Supported drives
 
-### Local driver
+### Local drive
 
-This driver is directly included in the `@apoyo/files` package. You don't need to install any other package.
+This drive is directly included in the `@apoyo/files` package. You don't need to install any other package.
 
-When using this driver, files are written on the local file system, starting at the given root path.
+When using this drive, files are written on the local file system, starting at the given root path.
 
 ```ts
-import { DriverContract, LocalDriver } from '@apoyo/files'
+import { Drive, LocalDrive } from '@apoyo/files'
 
-const driver: DriverContract = new LocalDriver({
+const drive: Drive = new LocalDrive({
   root: '/path/to/uploads'
 })
 ```
 
-### Fake driver
+### Fake drive
 
-This driver is directly included in the `@apoyo/files` package. You don't need to install any other package.
+This drive is directly included in the `@apoyo/files` package. You don't need to install any other package.
 
-When using this driver, files are written in memory. As such, this driver can be used when written tests, to avoid cluttering your system.
+When using this drive, files are written in memory. As such, this drive can be used when written tests, to avoid cluttering your system.
 
 ```ts
-import { DriverContract, FakeDriver } from '@apoyo/files'
+import { Drive, FakeDrive } from '@apoyo/files'
 
-const driver: DriverContract = new FakeDriver({})
+const drive: Drive = new FakeDrive()
 ```
 
-### S3 driver
+### S3 drive
 
-To use this driver, you will also need to install the `@apoyo/files-s3` package.
+To use this drive, you will also need to install the `@apoyo/files-s3` package.
 
-When using this driver, files are written in AWS S3.
+When using this drive, files are written in AWS S3.
 
 ```ts
-import { DriverContract } from '@apoyo/files'
-import { S3Driver } from '@apoyo/files-s3'
+import { Drive } from '@apoyo/files'
+import { S3Drive } from '@apoyo/files-s3'
 
-const driver: DriverContract = new S3Driver({
+const drive: Drive = new S3Drive({
   bucket: 'my-bucket',
   key: 'aws access key',
   secret: 'aws secret key'
 })
 ```
 
-**Note**: This driver is a framework agnostic version of [Adonisjs S3 Drive](https://github.com/adonisjs/drive-s3).
+**Note**: This drive is a framework agnostic version of [Adonisjs S3 Drive](https://github.com/adonisjs/drive-s3).
 
-### GCS driver
+### GCS drive
 
-To use this driver, you will also need to install the `@apoyo/files-gcs` package.
+To use this drive, you will also need to install the `@apoyo/files-gcs` package.
 
-When using this driver, files are written in AWS S3.
+When using this drive, files are written in AWS S3.
 
 ```ts
-import { DriverContract } from '@apoyo/files'
-import { GCSDriver } from '@apoyo/files-gcs'
+import { Drive } from '@apoyo/files'
+import { GCSDrive } from '@apoyo/files-gcs'
 
-const driver: DriverContract = new GCSDriver({
+const drive: Drive = new GCSDrive({
   // TODO
 })
 ```
 
-**Note**: This driver is a framework agnostic version of [Adonisjs GCS Drive](https://github.com/adonisjs/drive-gcs).
+**Note**: This drive is a framework agnostic version of [Adonisjs GCS Drive](https://github.com/adonisjs/drive-gcs).
 
-### Azure driver
+### Azure drive
 
-To use this driver, you will also need to install the `@apoyo/files-azure` package.
+To use this drive, you will also need to install the `@apoyo/files-azure` package.
 
-When using this driver, files are written in Azure Storage.
+When using this drive, files are written in Azure Storage.
 
 ```ts
-import { DriverContract } from '@apoyo/files'
-import { AzureDriver } from '@apoyo/files-azure'
+import { Drive } from '@apoyo/files'
+import { AzureDrive } from '@apoyo/files-azure'
 
-const driver: DriverContract = new AzureDriver({
+const drive: Drive = new AzureDrive({
   // TODO
 })
 ```
 
-**Note**: This driver is framework agnostic version of [Adonisjs Azure Drive](https://github.com/AlexanderYW/Adonis-Drive-Azure-Storage).
+**Note**: This drive is framework agnostic version of [Adonisjs Azure Drive](https://github.com/AlexanderYW/Adonis-Drive-Azure-Storage).
 
-### Custom drivers
+### Custom drive
 
-Custom providers can also be created by implementing the `DriverContract` interface available in `@apoyo/files`.
+Custom drives can also be created by implementing the `Drive` interface available in `@apoyo/files`.

--- a/packages/files-azure/package.json
+++ b/packages/files-azure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/files-azure",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "File driver for Azure Storage",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -39,7 +39,7 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.18.21",
@@ -50,7 +50,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15"
   },
   "publishConfig": {

--- a/packages/files-azure/src/drivers/azure.ts
+++ b/packages/files-azure/src/drivers/azure.ts
@@ -5,7 +5,7 @@ import {
   CannotWriteFileException,
   CannotDeleteFileException,
   CannotGetMetaDataException,
-  DriverContract
+  Drive
 } from '@apoyo/files'
 
 import { DriveFileStats } from '@apoyo/files'
@@ -28,7 +28,7 @@ import {
 } from '@azure/storage-blob'
 import { Readable } from 'stream'
 
-export type AzureDriverConfig = CommonOptions & {
+export type AzureDriveConfig = CommonOptions & {
   container: string
   connectionString?: string
   azureTenantId?: string
@@ -39,7 +39,7 @@ export type AzureDriverConfig = CommonOptions & {
   localAddress?: string
 }
 
-export class AzureDriver implements DriverContract {
+export class AzureDrive implements Drive {
   /**
    * Reference to the Azure storage instance
    */
@@ -50,7 +50,7 @@ export class AzureDriver implements DriverContract {
    */
   public name: 'azure' = 'azure'
 
-  constructor(private _config: AzureDriverConfig) {
+  constructor(private _config: AzureDriveConfig) {
     if (_config.connectionString) {
       // eslint-disable-next-line
       this.adapter = BlobServiceClient.fromConnectionString(

--- a/packages/files-azure/src/index.ts
+++ b/packages/files-azure/src/index.ts
@@ -1,1 +1,1 @@
-export { AzureDriver, AzureDriverConfig } from './drivers/azure'
+export { AzureDrive, AzureDriveConfig } from './drivers/azure'

--- a/packages/files-azure/tests/azure.spec.ts
+++ b/packages/files-azure/tests/azure.spec.ts
@@ -7,50 +7,50 @@ import {
   CannotReadFileException,
   FileException
 } from '@apoyo/files'
-import { AzureDriver, AzureDriverConfig } from '../src'
+import { AzureDrive, AzureDriveConfig } from '../src'
 import { Arr, Dict, pipe } from '@apoyo/std'
 
-describe('Azure Driver', () => {
-  let driver: AzureDriver
+describe('Azure Drive', () => {
+  let drive: AzureDrive
 
   beforeEach(async () => {
     // Check https://github.com/Azure/Azurite#usage-with-azure-storage-sdks-or-tools for more information.
-    const config: AzureDriverConfig = {
+    const config: AzureDriveConfig = {
       container: 'test',
       name: 'devstoreaccount1',
       key: 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
       localAddress: 'http://devstoreaccount1.blob.localhost:10000'
     }
 
-    driver = new AzureDriver(config)
+    drive = new AzureDrive(config)
 
-    const containerClient = driver.adapter.getContainerClient('test')
+    const containerClient = drive.adapter.getContainerClient('test')
     await containerClient.deleteIfExists()
     await containerClient.create()
   })
 
   describe('put', () => {
     it('write file to the destination', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when missing', async () => {
-      await driver.put('bar/baz/foo.txt', 'hello world')
+      await drive.put('bar/baz/foo.txt', 'hello world')
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('overwrite destination when file already exists', async () => {
-      await driver.put('foo.txt', 'hi world')
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
@@ -66,10 +66,10 @@ describe('Azure Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('foo.txt', stream)
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -82,10 +82,10 @@ describe('Azure Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('bar/baz/foo.txt', stream)
+      await drive.putStream('bar/baz/foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -98,69 +98,69 @@ describe('Azure Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.put('foo.txt', 'hi world')
-      await driver.putStream('foo.txt', stream)
+      await drive.put('foo.txt', 'hi world')
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('exists', () => {
     it('return true when a file exists', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
+      await drive.put('bar/baz/foo.txt', 'bar')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(true)
     })
 
     it("return false when a file doesn't exists", async () => {
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return false when a file parent directory doesn't exists", async () => {
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('delete', () => {
     it('remove file', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      await driver.delete('bar/baz/foo.txt')
+      await drive.put('bar/baz/foo.txt', 'bar')
+      await drive.delete('bar/baz/foo.txt')
 
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
 
     it('do not error when trying to remove a non-existing file', async () => {
-      await driver.delete('foo.txt')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      await drive.delete('foo.txt')
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("do not error when file parent directory doesn't exists", async () => {
-      await driver.delete('bar/baz/foo.txt')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      await drive.delete('bar/baz/foo.txt')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('copy', () => {
     it('copy file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when copying a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.copy('foo.txt', 'bar.txt')
+        await drive.copy('foo.txt', 'bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotCopyFileException)
@@ -169,37 +169,37 @@ describe('Azure Driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('bar.txt', 'hi world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('bar.txt', 'hi world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('move', () => {
     it('move file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it('create intermediate directories when moving a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.move('foo.txt', 'baz/bar.txt')
+        await drive.move('foo.txt', 'baz/bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotMoveFileException)
@@ -208,28 +208,28 @@ describe('Azure Driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('baz/bar.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('baz/bar.txt', 'hi world')
 
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('get', () => {
     it('get file contents', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('get file contents as a stream', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stream = await driver.getStream('foo.txt')
+      const stream = await drive.getStream('foo.txt')
 
       await new Promise<void>((resolve) => {
         stream.on('data', (chunk) => {
@@ -241,7 +241,7 @@ describe('Azure Driver', () => {
 
     it("return error when file doesn't exists", async () => {
       try {
-        await driver.get('foo.txt')
+        await drive.get('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotReadFileException)
@@ -252,16 +252,16 @@ describe('Azure Driver', () => {
 
   describe('getStats', () => {
     it('get file stats', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stats = await driver.getStats('foo.txt')
+      const stats = await drive.getStats('foo.txt')
       expect(stats.size).toBe(11)
       expect(stats.modified).toBeInstanceOf(Date)
     })
 
     it('return error when file is missing', async () => {
       try {
-        await driver.getStats('foo.txt')
+        await drive.getStats('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotGetMetaDataException)
@@ -272,14 +272,14 @@ describe('Azure Driver', () => {
 
   describe('getUrl', () => {
     it('get url to a given file', async () => {
-      const url = await driver.getUrl('foo.txt')
+      const url = await drive.getUrl('foo.txt')
       expect(url).toBe('http://devstoreaccount1.blob.localhost:10000/test/foo.txt')
     })
   })
 
   describe('getSignedUrl', () => {
     it('get signed url to a given file', async () => {
-      const url = await driver.getSignedUrl('foo.txt')
+      const url = await drive.getSignedUrl('foo.txt')
       const parsed = new URL(url)
       const queryParams = pipe(parsed.searchParams.entries(), Arr.from, Dict.fromPairs)
       expect(parsed.origin + parsed.pathname).toBe('http://devstoreaccount1.blob.localhost:10000/test/foo.txt')

--- a/packages/files-gcs/package.json
+++ b/packages/files-gcs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/files-gcs",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "File driver for GCS",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -39,7 +39,7 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.18.21",
@@ -50,7 +50,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15"
   },
   "publishConfig": {

--- a/packages/files-gcs/src/drivers/gcs.ts
+++ b/packages/files-gcs/src/drivers/gcs.ts
@@ -10,7 +10,7 @@ import {
   CannotWriteFileException,
   ContentHeaders,
   DriveFileStats,
-  DriverContract,
+  Drive,
   SignedUrlOptions,
   WriteOptions
 } from '@apoyo/files'
@@ -18,13 +18,13 @@ import { Bucket, GetSignedUrlConfig, Storage, StorageOptions } from '@google-clo
 
 const pipelinePromise = promisify(pipeline)
 
-export type GcsDriverConfig = StorageOptions & {
+export type GcsDriveConfig = StorageOptions & {
   bucket: string
   usingUniformAcl?: boolean
   cdnUrl?: string
 }
 
-export class GcsDriver implements DriverContract {
+export class GcsDrive implements Drive {
   /**
    * Reference to the GCS Bucket
    */
@@ -40,7 +40,7 @@ export class GcsDriver implements DriverContract {
    */
   public name: 'gcs' = 'gcs'
 
-  constructor(private _config: GcsDriverConfig) {
+  constructor(private _config: GcsDriveConfig) {
     this.adapter = new Storage(this._config)
     this._gcsBucket = this.adapter.bucket(this._config.bucket)
   }
@@ -106,8 +106,8 @@ export class GcsDriver implements DriverContract {
    * Returns a new instance of the GCS driver with
    * a custom runtime bucket
    */
-  public bucket(bucket: string): GcsDriver {
-    return new GcsDriver(Object.assign({}, this._config, { bucket }))
+  public bucket(bucket: string): GcsDrive {
+    return new GcsDrive(Object.assign({}, this._config, { bucket }))
   }
 
   /**

--- a/packages/files-gcs/src/index.ts
+++ b/packages/files-gcs/src/index.ts
@@ -1,1 +1,1 @@
-export { GcsDriver, GcsDriverConfig } from './drivers/gcs'
+export { GcsDrive, GcsDriveConfig } from './drivers/gcs'

--- a/packages/files-gcs/tests/gcs.spec.ts
+++ b/packages/files-gcs/tests/gcs.spec.ts
@@ -5,22 +5,22 @@ import {
   CannotGetMetaDataException,
   CannotMoveFileException,
   CannotReadFileException,
-  DriverContract,
+  Drive,
   FileException
 } from '@apoyo/files'
-import { GcsDriver, GcsDriverConfig } from '../src'
+import { GcsDrive, GcsDriveConfig } from '../src'
 
-describe('GCS Driver', () => {
-  let driver: DriverContract
+describe('GCS Drive', () => {
+  let drive: Drive
 
   beforeEach(async () => {
-    const config: GcsDriverConfig = {
+    const config: GcsDriveConfig = {
       apiEndpoint: 'http://localhost:4443',
       bucket: 'test',
       projectId: 'test'
     }
 
-    const gcs = new GcsDriver(config)
+    const gcs = new GcsDrive(config)
 
     const [buckets] = await gcs.adapter.getBuckets()
     const exists = buckets.find((bucket) => bucket.name === 'test') !== undefined
@@ -28,38 +28,38 @@ describe('GCS Driver', () => {
       await gcs.adapter.createBucket('test')
     }
 
-    driver = gcs
+    drive = gcs
   })
 
   afterEach(async () => {
-    await driver.delete('foo.txt')
-    await driver.delete('bar.txt')
-    await driver.delete('baz/bar.txt')
-    await driver.delete('bar/baz/foo.txt')
+    await drive.delete('foo.txt')
+    await drive.delete('bar.txt')
+    await drive.delete('baz/bar.txt')
+    await drive.delete('bar/baz/foo.txt')
   })
 
   describe('put', () => {
     it('write file to the destination', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when missing', async () => {
-      await driver.put('bar/baz/foo.txt', 'hello world')
+      await drive.put('bar/baz/foo.txt', 'hello world')
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('overwrite destination when file already exists', async () => {
-      await driver.put('foo.txt', 'hi world')
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
@@ -75,10 +75,10 @@ describe('GCS Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('foo.txt', stream)
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -91,10 +91,10 @@ describe('GCS Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('bar/baz/foo.txt', stream)
+      await drive.putStream('bar/baz/foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -107,69 +107,69 @@ describe('GCS Driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.put('foo.txt', 'hi world')
-      await driver.putStream('foo.txt', stream)
+      await drive.put('foo.txt', 'hi world')
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('exists', () => {
     it('return true when a file exists', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
+      await drive.put('bar/baz/foo.txt', 'bar')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(true)
     })
 
     it("return false when a file doesn't exists", async () => {
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return false when a file parent directory doesn't exists", async () => {
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('delete', () => {
     it('remove file', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      await driver.delete('bar/baz/foo.txt')
+      await drive.put('bar/baz/foo.txt', 'bar')
+      await drive.delete('bar/baz/foo.txt')
 
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
 
     it('do not error when trying to remove a non-existing file', async () => {
-      await driver.delete('foo.txt')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      await drive.delete('foo.txt')
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("do not error when file parent directory doesn't exists", async () => {
-      await driver.delete('bar/baz/foo.txt')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      await drive.delete('bar/baz/foo.txt')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('copy', () => {
     it('copy file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when copying a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.copy('foo.txt', 'bar.txt')
+        await drive.copy('foo.txt', 'bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotCopyFileException)
@@ -178,37 +178,37 @@ describe('GCS Driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('bar.txt', 'hi world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('bar.txt', 'hi world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('move', () => {
     it('move file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it('create intermediate directories when moving a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.move('foo.txt', 'baz/bar.txt')
+        await drive.move('foo.txt', 'baz/bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotMoveFileException)
@@ -217,28 +217,28 @@ describe('GCS Driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('baz/bar.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('baz/bar.txt', 'hi world')
 
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('get', () => {
     it('get file contents', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('get file contents as a stream', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stream = await driver.getStream('foo.txt')
+      const stream = await drive.getStream('foo.txt')
 
       await new Promise<void>((resolve) => {
         stream.on('data', (chunk) => {
@@ -250,7 +250,7 @@ describe('GCS Driver', () => {
 
     it("return error when file doesn't exists", async () => {
       try {
-        await driver.get('foo.txt')
+        await drive.get('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotReadFileException)
@@ -261,16 +261,16 @@ describe('GCS Driver', () => {
 
   describe('getStats', () => {
     it('get file stats', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stats = await driver.getStats('foo.txt')
+      const stats = await drive.getStats('foo.txt')
       expect(stats.size).toBe(11)
       expect(stats.modified).toBeInstanceOf(Date)
     })
 
     it('return error when file is missing', async () => {
       try {
-        await driver.getStats('foo.txt')
+        await drive.getStats('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotGetMetaDataException)
@@ -281,7 +281,7 @@ describe('GCS Driver', () => {
 
   describe('getUrl', () => {
     it('get url to a given file', async () => {
-      const url = await driver.getUrl('foo.txt')
+      const url = await drive.getUrl('foo.txt')
       expect(url).toBe('http://localhost:4443/test/foo.txt')
     })
   })

--- a/packages/files-s3/package.json
+++ b/packages/files-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/files-s3",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "File driver for S3",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -39,7 +39,7 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15",
     "@types/jest": "^26.0.23",
     "@types/node": "^14.18.21",
@@ -50,7 +50,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@apoyo/files": "~0.0.2",
+    "@apoyo/files": "~0.1.0",
     "@apoyo/std": "0.0.15"
   },
   "dependencies": {

--- a/packages/files-s3/src/drivers/s3.ts
+++ b/packages/files-s3/src/drivers/s3.ts
@@ -10,7 +10,7 @@ import {
   CannotWriteFileException,
   ContentHeaders,
   DriveFileStats,
-  DriverContract,
+  Drive,
   SignedUrlOptions,
   WriteOptions
 } from '@apoyo/files'
@@ -28,7 +28,7 @@ import {
 import { Upload } from '@aws-sdk/lib-storage'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
-export type S3DriverConfig = S3ClientConfig & {
+export type S3DriveConfig = S3ClientConfig & {
   bucket: string
   cdnUrl?: string
   key?: string
@@ -38,7 +38,7 @@ export type S3DriverConfig = S3ClientConfig & {
 /**
  * An implementation of the s3 driver for AdonisJS drive
  */
-export class S3Driver implements DriverContract {
+export class S3Drive implements Drive {
   /**
    * Reference to the s3 client
    */
@@ -49,7 +49,7 @@ export class S3Driver implements DriverContract {
    */
   public name: 's3' = 's3'
 
-  constructor(private _config: S3DriverConfig) {
+  constructor(private _config: S3DriveConfig) {
     /**
      * Use the top level key and secret to define AWS credentials
      */
@@ -127,14 +127,6 @@ export class S3Driver implements DriverContract {
     }
 
     return contentHeaders
-  }
-
-  /**
-   * Returns a new instance of the s3 driver with a custom runtime
-   * bucket
-   */
-  public bucket(bucket: string): S3Driver {
-    return new S3Driver(Object.assign({}, this._config, { bucket }))
   }
 
   /**

--- a/packages/files-s3/src/index.ts
+++ b/packages/files-s3/src/index.ts
@@ -1,1 +1,1 @@
-export { S3Driver, S3DriverConfig } from './drivers/s3'
+export { S3Drive, S3DriveConfig } from './drivers/s3'

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apoyo/files",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Utils focused around files management",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/files/src/drive.ts
+++ b/packages/files/src/drive.ts
@@ -37,7 +37,7 @@ export type DriveFileStats = {
 /**
  * Shape of the generic driver
  */
-export interface DriverContract {
+export interface Drive {
   /**
    * Name of the driver
    */

--- a/packages/files/src/drivers/fake.ts
+++ b/packages/files/src/drivers/fake.ts
@@ -2,7 +2,7 @@ import etag from 'etag'
 import { Volume } from 'memfs'
 import { dirname } from 'path'
 
-import { DriveFileStats, DriverContract, SignedUrlOptions } from '../driver'
+import { DriveFileStats, Drive, SignedUrlOptions } from '../drive'
 
 import { pipelinePromise } from '../utils'
 
@@ -17,7 +17,7 @@ import {
 } from '../exceptions'
 import { Exception } from '@apoyo/std'
 
-export interface FakeDriverConfig {
+export interface FakeDriveConfig {
   /**
    * Configure how `getUrl` and `getSignedUrl` computes the URL for a given file
    */
@@ -28,9 +28,9 @@ export interface FakeDriverConfig {
 }
 
 /**
- * Memory driver is mainly used for testing
+ * Memory drive is mainly used for testing
  */
-export class FakeDriver implements DriverContract {
+export class FakeDrive implements Drive {
   /**
    * Reference to the underlying adapter. Which is memfs
    */
@@ -41,7 +41,7 @@ export class FakeDriver implements DriverContract {
    */
   public name: 'fake' = 'fake'
 
-  constructor(private _config: FakeDriverConfig) {}
+  constructor(private _config: FakeDriveConfig = {}) {}
 
   /**
    * Make absolute path to a given location

--- a/packages/files/src/drivers/local.ts
+++ b/packages/files/src/drivers/local.ts
@@ -2,7 +2,7 @@ import etag from 'etag'
 import * as fsExtra from 'fs-extra'
 import path, { dirname } from 'path'
 
-import { DriveFileStats, DriverContract, SignedUrlOptions } from '../driver'
+import { DriveFileStats, Drive, SignedUrlOptions } from '../drive'
 
 import { pipelinePromise } from '../utils'
 
@@ -16,7 +16,7 @@ import {
   CannotGetMetaDataException
 } from '../exceptions'
 
-export interface LocalDriverConfig {
+export interface LocalDriveConfig {
   /**
    * Root directory in which to search for your files on your local filesystem
    */
@@ -34,7 +34,7 @@ export interface LocalDriverConfig {
 /**
  * Local driver interacts with the local file system
  */
-export class LocalDriver implements DriverContract {
+export class LocalDrive implements Drive {
   /**
    * Reference to the underlying adapter. Which is
    * fs-extra
@@ -46,7 +46,7 @@ export class LocalDriver implements DriverContract {
    */
   public name: 'local' = 'local'
 
-  constructor(private _config: LocalDriverConfig) {}
+  constructor(private _config: LocalDriveConfig) {}
 
   /**
    * Make absolute path to a given location

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -1,4 +1,4 @@
-export * from './driver'
+export * from './drive'
 export * from './exceptions'
-export { LocalDriver, LocalDriverConfig } from './drivers/local'
-export { FakeDriver, FakeDriverConfig } from './drivers/fake'
+export { LocalDrive, LocalDriveConfig } from './drivers/local'
+export { FakeDrive, FakeDriveConfig as FakeDriverConfig } from './drivers/fake'

--- a/packages/files/tests/drivers/fake.spec.ts
+++ b/packages/files/tests/drivers/fake.spec.ts
@@ -9,9 +9,9 @@ import {
   CannotMoveFileException,
   CannotReadFileException,
   FileException,
-  FakeDriver,
+  FakeDrive,
   FakeDriverConfig,
-  DriverContract,
+  Drive,
   SignedUrlOptions
 } from '../../src'
 
@@ -38,8 +38,8 @@ function makeSignedUrl(location: string, _options?: SignedUrlOptions) {
   )
 }
 
-describe('Fake driver', () => {
-  let driver: DriverContract
+describe('Fake drive', () => {
+  let drive: Drive
 
   beforeEach(async () => {
     const config: FakeDriverConfig = {
@@ -48,31 +48,31 @@ describe('Fake driver', () => {
         makeSignedUrl
       }
     }
-    driver = new FakeDriver(config)
+    drive = new FakeDrive(config)
   })
 
   describe('put', () => {
     it('write file to the destination', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when missing', async () => {
-      await driver.put('bar/baz/foo.txt', 'hello world')
+      await drive.put('bar/baz/foo.txt', 'hello world')
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('overwrite destination when file already exists', async () => {
-      await driver.put('foo.txt', 'hi world')
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
@@ -88,10 +88,10 @@ describe('Fake driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('foo.txt', stream)
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -104,10 +104,10 @@ describe('Fake driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('bar/baz/foo.txt', stream)
+      await drive.putStream('bar/baz/foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -120,69 +120,69 @@ describe('Fake driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.put('foo.txt', 'hi world')
-      await driver.putStream('foo.txt', stream)
+      await drive.put('foo.txt', 'hi world')
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('exists', () => {
     it('return true when a file exists', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
+      await drive.put('bar/baz/foo.txt', 'bar')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(true)
     })
 
     it("return false when a file doesn't exists", async () => {
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return false when a file parent directory doesn't exists", async () => {
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('delete', () => {
     it('remove file', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      await driver.delete('bar/baz/foo.txt')
+      await drive.put('bar/baz/foo.txt', 'bar')
+      await drive.delete('bar/baz/foo.txt')
 
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
 
     it('do not error when trying to remove a non-existing file', async () => {
-      await driver.delete('foo.txt')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      await drive.delete('foo.txt')
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("do not error when file parent directory doesn't exists", async () => {
-      await driver.delete('bar/baz/foo.txt')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      await drive.delete('bar/baz/foo.txt')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('copy', () => {
     it('copy file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when copying a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.copy('foo.txt', 'bar.txt')
+        await drive.copy('foo.txt', 'bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotCopyFileException)
@@ -191,37 +191,37 @@ describe('Fake driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('bar.txt', 'hi world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('bar.txt', 'hi world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('move', () => {
     it('move file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it('create intermediate directories when moving a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.move('foo.txt', 'baz/bar.txt')
+        await drive.move('foo.txt', 'baz/bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotMoveFileException)
@@ -230,28 +230,28 @@ describe('Fake driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('baz/bar.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('baz/bar.txt', 'hi world')
 
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('get', () => {
     it('get file contents', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('get file contents as a stream', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stream = await driver.getStream('foo.txt')
+      const stream = await drive.getStream('foo.txt')
 
       await new Promise<void>((resolve) => {
         stream.on('data', (chunk) => {
@@ -263,7 +263,7 @@ describe('Fake driver', () => {
 
     it("return error when file doesn't exists", async () => {
       try {
-        await driver.get('foo.txt')
+        await drive.get('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotReadFileException)
@@ -274,16 +274,16 @@ describe('Fake driver', () => {
 
   describe('getStats', () => {
     it('get file stats', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stats = await driver.getStats('foo.txt')
+      const stats = await drive.getStats('foo.txt')
       expect(stats.size).toBe(11)
       expect(stats.modified).toBeInstanceOf(Date)
     })
 
     it('return error when file is missing', async () => {
       try {
-        await driver.getStats('foo.txt')
+        await drive.getStats('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotGetMetaDataException)
@@ -294,14 +294,14 @@ describe('Fake driver', () => {
 
   describe('getUrl', () => {
     it('get url to a given file', async () => {
-      const url = await driver.getUrl('foo.txt')
+      const url = await drive.getUrl('foo.txt')
       expect(url).toBe('/uploads/foo.txt')
     })
   })
 
   describe('getSignedUrl', () => {
     it('get signed url to a given file', async () => {
-      const url = await driver.getSignedUrl('foo.txt')
+      const url = await drive.getSignedUrl('foo.txt')
       expect(url).toMatch(/\/uploads\/foo\.txt\?sign=.*/)
     })
   })

--- a/packages/files/tests/drivers/local.spec.ts
+++ b/packages/files/tests/drivers/local.spec.ts
@@ -10,10 +10,10 @@ import {
   CannotGetMetaDataException,
   CannotMoveFileException,
   CannotReadFileException,
-  DriverContract,
+  Drive,
   FileException,
-  LocalDriver,
-  LocalDriverConfig,
+  LocalDrive,
+  LocalDriveConfig,
   SignedUrlOptions
 } from '../../src'
 
@@ -46,18 +46,18 @@ function makeSignedUrl(location: string, _options?: SignedUrlOptions) {
   )
 }
 
-describe('Local driver', () => {
-  let driver: DriverContract
+describe('Local drive', () => {
+  let drive: Drive
 
   beforeEach(async () => {
-    const config: LocalDriverConfig = {
+    const config: LocalDriveConfig = {
       root: TEST_ROOT,
       serveFiles: {
         makeUrl,
         makeSignedUrl
       }
     }
-    driver = new LocalDriver(config)
+    drive = new LocalDrive(config)
   })
 
   afterEach(async () => {
@@ -66,26 +66,26 @@ describe('Local driver', () => {
 
   describe('put', () => {
     it('write file to the destination', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when missing', async () => {
-      await driver.put('bar/baz/foo.txt', 'hello world')
+      await drive.put('bar/baz/foo.txt', 'hello world')
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
 
     it('overwrite destination when file already exists', async () => {
-      await driver.put('foo.txt', 'hi world')
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
 
       expect(contents.toString()).toBe('hello world')
     })
@@ -101,10 +101,10 @@ describe('Local driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('foo.txt', stream)
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -117,10 +117,10 @@ describe('Local driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.putStream('bar/baz/foo.txt', stream)
+      await drive.putStream('bar/baz/foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('bar/baz/foo.txt')
+      const contents = await drive.get('bar/baz/foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
@@ -133,69 +133,69 @@ describe('Local driver', () => {
       })
 
       expect(stream.readable).toBe(true)
-      await driver.put('foo.txt', 'hi world')
-      await driver.putStream('foo.txt', stream)
+      await drive.put('foo.txt', 'hi world')
+      await drive.putStream('foo.txt', stream)
       expect(stream.readable).toBe(false)
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('exists', () => {
     it('return true when a file exists', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(true)
+      await drive.put('bar/baz/foo.txt', 'bar')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(true)
     })
 
     it("return false when a file doesn't exists", async () => {
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return false when a file parent directory doesn't exists", async () => {
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('delete', () => {
     it('remove file', async () => {
-      await driver.put('bar/baz/foo.txt', 'bar')
-      await driver.delete('bar/baz/foo.txt')
+      await drive.put('bar/baz/foo.txt', 'bar')
+      await drive.delete('bar/baz/foo.txt')
 
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
 
     it('do not error when trying to remove a non-existing file', async () => {
-      await driver.delete('foo.txt')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      await drive.delete('foo.txt')
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("do not error when file parent directory doesn't exists", async () => {
-      await driver.delete('bar/baz/foo.txt')
-      expect(await driver.exists('bar/baz/foo.txt')).toBe(false)
+      await drive.delete('bar/baz/foo.txt')
+      expect(await drive.exists('bar/baz/foo.txt')).toBe(false)
     })
   })
 
   describe('copy', () => {
     it('copy file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('create intermediate directories when copying a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.copy('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.copy('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.copy('foo.txt', 'bar.txt')
+        await drive.copy('foo.txt', 'bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotCopyFileException)
@@ -204,37 +204,37 @@ describe('Local driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('bar.txt', 'hi world')
-      await driver.copy('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('bar.txt', 'hi world')
+      await drive.copy('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('move', () => {
     it('move file from within the disk root', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'bar.txt')
 
-      const contents = await driver.get('bar.txt')
+      const contents = await drive.get('bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it('create intermediate directories when moving a file', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.put('foo.txt', 'hello world')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
-      expect(await driver.exists('foo.txt')).toBe(false)
+      expect(await drive.exists('foo.txt')).toBe(false)
     })
 
     it("return error when source doesn't exists", async () => {
       try {
-        await driver.move('foo.txt', 'baz/bar.txt')
+        await drive.move('foo.txt', 'baz/bar.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotMoveFileException)
@@ -243,28 +243,28 @@ describe('Local driver', () => {
     })
 
     it('overwrite destination when already exists', async () => {
-      await driver.put('foo.txt', 'hello world')
-      await driver.put('baz/bar.txt', 'hi world')
+      await drive.put('foo.txt', 'hello world')
+      await drive.put('baz/bar.txt', 'hi world')
 
-      await driver.move('foo.txt', 'baz/bar.txt')
+      await drive.move('foo.txt', 'baz/bar.txt')
 
-      const contents = await driver.get('baz/bar.txt')
+      const contents = await drive.get('baz/bar.txt')
       expect(contents.toString()).toBe('hello world')
     })
   })
 
   describe('get', () => {
     it('get file contents', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const contents = await driver.get('foo.txt')
+      const contents = await drive.get('foo.txt')
       expect(contents.toString()).toBe('hello world')
     })
 
     it('get file contents as a stream', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stream = await driver.getStream('foo.txt')
+      const stream = await drive.getStream('foo.txt')
 
       await new Promise<void>((resolve) => {
         stream.on('data', (chunk) => {
@@ -276,7 +276,7 @@ describe('Local driver', () => {
 
     it("return error when file doesn't exists", async () => {
       try {
-        await driver.get('foo.txt')
+        await drive.get('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotReadFileException)
@@ -287,16 +287,16 @@ describe('Local driver', () => {
 
   describe('getStats', () => {
     it('get file stats', async () => {
-      await driver.put('foo.txt', 'hello world')
+      await drive.put('foo.txt', 'hello world')
 
-      const stats = await driver.getStats('foo.txt')
+      const stats = await drive.getStats('foo.txt')
       expect(stats.size).toBe(11)
       expect(stats.modified).toBeInstanceOf(Date)
     })
 
     it('return error when file is missing', async () => {
       try {
-        await driver.getStats('foo.txt')
+        await drive.getStats('foo.txt')
       } catch (error) {
         expect(error).toBeInstanceOf(FileException)
         expect(error).toBeInstanceOf(CannotGetMetaDataException)
@@ -307,14 +307,14 @@ describe('Local driver', () => {
 
   describe('getUrl', () => {
     it('get url to a given file', async () => {
-      const url = await driver.getUrl('foo.txt')
+      const url = await drive.getUrl('foo.txt')
       expect(url).toBe('/uploads/foo.txt')
     })
   })
 
   describe('getSignedUrl', () => {
     it('get signed url to a given file', async () => {
-      const url = await driver.getSignedUrl('foo.txt')
+      const url = await drive.getSignedUrl('foo.txt')
       expect(url).toMatch(/\/uploads\/foo\.txt\?sign=.*/)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,7 +85,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@apoyo/files-azure@workspace:packages/files-azure"
   dependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
     "@azure/identity": ^2.1.0
     "@azure/storage-blob": ^12.11.0
@@ -97,7 +97,7 @@ __metadata:
     tsup: ^6.1.2
     typescript: ^4.7.4
   peerDependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
   languageName: unknown
   linkType: soft
@@ -106,7 +106,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@apoyo/files-gcs@workspace:packages/files-gcs"
   dependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
     "@google-cloud/storage": ^6.4.1
     "@types/jest": ^26.0.23
@@ -117,7 +117,7 @@ __metadata:
     tsup: ^6.1.2
     typescript: ^4.7.4
   peerDependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
   languageName: unknown
   linkType: soft
@@ -126,7 +126,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@apoyo/files-s3@workspace:packages/files-s3"
   dependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
     "@aws-sdk/abort-controller": ^3.162.0
     "@aws-sdk/client-s3": ^3.161.0
@@ -141,12 +141,12 @@ __metadata:
     tsup: ^6.1.2
     typescript: ^4.7.4
   peerDependencies:
-    "@apoyo/files": ~0.0.2
+    "@apoyo/files": ~0.1.0
     "@apoyo/std": 0.0.15
   languageName: unknown
   linkType: soft
 
-"@apoyo/files@workspace:packages/files, @apoyo/files@~0.0.2":
+"@apoyo/files@workspace:packages/files, @apoyo/files@~0.1.0":
   version: 0.0.0-use.local
   resolution: "@apoyo/files@workspace:packages/files"
   dependencies:


### PR DESCRIPTION
**Breaking changes**:

- `DriverContract` interface has been renamed into `Drive` => cleaner interface to import in userland code
- `LocalDriver` renamed into `LocalDrive`
- `FakeDriver` renamed into `FakeDrive`
- `AzureDriver` renamed into `AzureDrive`
- `GcsDriver` renamed into `GcsDrive`
- `S3Driver` renamed into `S3Drive`
- The config types have been renamed in the same fashion