### PR TITLE
feat(logger): separate logger from process package into an independent package

### DIFF
--- a/packages/logger/CHANGELOG.md
+++ b/packages/logger/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/packages/logger/LICENSE
+++ b/packages/logger/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-present Sascha Braun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,19 @@
+# Apoyo - Logger
+
+[![npm version](https://badgen.net/npm/v/@apoyo/logger)](https://www.npmjs.com/package/@apoyo/logger)
+
+## Installation
+
+Install peer dependencies:
+`npm install @apoyo/std`
+
+Install package:
+`npm install @apoyo/logger`
+
+## Documentation
+
+TODO
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -2,6 +2,8 @@
 
 [![npm version](https://badgen.net/npm/v/@apoyo/logger)](https://www.npmjs.com/package/@apoyo/logger)
 
+**Warning**: This package is still in development and is not recommended to use in production yet.
+
 ## Installation
 
 Install peer dependencies:
@@ -12,7 +14,55 @@ Install package:
 
 ## Documentation
 
-TODO
+This package contains utils around Pino loggers.
+
+It adds once again the `prettyPrint` option to more easily enable pretty printing in development, with sensible defaults.
+
+It also contains a `LoggerContext` that, using `AsyncLocalStorage`, allows us to add additional bindings to each logger in a same asynchronous scope easily.
+
+```ts
+import { createLogger, LogLevel, LoggerContext } from '@apoyo/logger'
+
+const loggerContext = new LoggerContext()
+const logger = createLogger(
+  {
+    level: LogLevel.INFO,
+    prettyPrint: true
+  }, 
+  loggerContext // This parameter is optional
+)
+
+const featureLogger = logger.child({
+  name: 'MyFeature',
+  foo: 'bar' 
+})
+
+const reqLogger = logger.child({
+  name: 'Http',
+  foo: 'foo',
+  req: {
+    id: 'xxx-xxx-xxx'
+  }
+})
+
+loggerContext.attachBindings(reqLogger.bindings(), async () => {
+  /*
+   * Logs the following custom properties (not including the message, level and other default pino properties):
+   * ```
+   * {
+   *   name: 'MyFeature', 
+   *   foo: 'bar', 
+   *   req: { 
+   *     id: 'xxx-xxx-xxx' 
+   *   }
+   * }
+   * ```
+   */
+  featureLogger.info('hello world')
+})
+```
+
+A more complete documentation will be written when the package becomes stable.
 
 ## License
 

--- a/packages/logger/jest.config.js
+++ b/packages/logger/jest.config.js
@@ -1,0 +1,24 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(/tests/.*|\\.(test|spec))\\.(ts|tsx|js)$',
+  transform: {
+    '.(ts|tsx)': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@apoyo/(.*?)$': '<rootDir>/../../packages/$1/src'
+  },
+  collectCoverage: true,
+  coveragePathIgnorePatterns: ['/node_modules/', '/test/'],
+  /* FIXME: Enable threshold again when coverage has progressed on the project
+  coverageThreshold: {
+    global: {
+      branches: 90,
+      functions: 90,
+      lines: 90,
+      statements: 90
+    }
+  },*/
+  collectCoverageFrom: ['src/*.{js,ts}']
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@apoyo/logger",
+  "version": "0.0.1",
+  "description": "Utils focused around pino logger",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md",
+    "package.json"
+  ],
+  "sideEffects": false,
+  "author": "Sascha Braun",
+  "license": "MIT",
+  "tags": [
+    "utils",
+    "logger",
+    "pino",
+    "pino-pretty"
+  ],
+  "keywords": [
+    "utils",
+    "logger",
+    "pino",
+    "pino-pretty"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/neoxia/apoyo"
+  },
+  "homepage": "https://github.com/neoxia/apoyo/tree/master/packages/logger",
+  "scripts": {
+    "test": "jest --verbose --runInBand",
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@apoyo/std": "^0.0.15",
+    "@types/jest": "^26.0.23",
+    "@types/node": "^16.18.0",
+    "jest": "^26.4.2",
+    "ts-jest": "^26.3.0",
+    "ts-node": "^8.0.2",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@apoyo/std": "^0.0.15"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "pino": "^8.7.0",
+    "pino-pretty": "^9.1.1"
+  }
+}

--- a/packages/logger/src/config.ts
+++ b/packages/logger/src/config.ts
@@ -1,0 +1,26 @@
+import { Bindings, ChildLoggerOptions as PinoChildOptions, LoggerOptions as PinoOptions } from 'pino'
+import { PrettyOptions } from 'pino-pretty'
+import { Writable } from 'stream'
+
+export enum LogLevel {
+  FATAL = 'fatal',
+  ERROR = 'error',
+  WARN = 'warn',
+  INFO = 'info',
+  DEBUG = 'debug',
+  TRACE = 'trace',
+  SILENT = 'silent'
+}
+
+export interface LoggerOptions extends Omit<PinoOptions, 'transport'> {
+  enabled?: boolean
+  level?: LogLevel
+  prettyPrint?: Omit<PrettyOptions, 'destination'> | boolean
+  destination?: Writable
+}
+
+export interface LoggerChildOptions extends PinoChildOptions {
+  name?: string
+  level?: LogLevel
+  bindings?: Bindings
+}

--- a/packages/logger/src/context.ts
+++ b/packages/logger/src/context.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from 'async_hooks'
+import { Bindings } from 'pino'
+
+export class LoggerContext {
+  private _storage = new AsyncLocalStorage<Bindings>()
+
+  public attachBindings<T>(bindings: Bindings, fn: () => T) {
+    const parent = this.bindings()
+    return this._storage.run(
+      {
+        ...parent,
+        ...bindings
+      },
+      fn
+    )
+  }
+
+  public bindings() {
+    return this._storage.getStore()
+  }
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,3 @@
+export * from './context'
+export * from './config'
+export * from './logger'

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,5 +1,5 @@
-import { Obj, pipe } from '@apoyo/std'
-import pino, { LoggerOptions as PinoOptions } from 'pino'
+import { Dict, Obj, pipe } from '@apoyo/std'
+import pino, { Bindings, Logger, LoggerOptions as PinoOptions } from 'pino'
 import pinoPretty from 'pino-pretty'
 
 import { LoggerOptions } from './config'
@@ -21,21 +21,50 @@ export function createLogger(config: LoggerOptions, context?: LoggerContext) {
       })
     : out
 
-  const mixin: PinoOptions['mixin'] = () => {
-    const bindings = context?.bindings()
+  const configWithoutPretty = pipe(config, Obj.omit(['prettyPrint', 'destination']))
+
+  const createLogWithContext = (
+    loggerBindings: () => Bindings,
+    superLog?: (obj: Record<string, unknown>) => Record<string, unknown>
+  ) => (object: Record<string, unknown>) => {
+    const ctxBindings = context?.bindings() ?? {}
+    const props = pipe(ctxBindings, Dict.difference(loggerBindings()))
     return {
-      ...bindings
+      ...props,
+      ...(superLog ? superLog(object) : object)
     }
   }
 
-  const configWithoutPretty = pipe(config, Obj.omit(['prettyPrint']))
+  const formatters = context
+    ? {
+        ...configWithoutPretty.formatters,
+        log: createLogWithContext(() => logger.bindings(), configWithoutPretty.formatters?.log)
+      }
+    : configWithoutPretty.formatters
 
   const options: PinoOptions = {
     ...configWithoutPretty,
     enabled: config.enabled ?? true,
     level: config.level ?? 'info',
-    mixin
+    formatters
   }
 
-  return pino(options, stream)
+  const logger = pino(options, stream)
+
+  if (context) {
+    const child = logger.child.bind(logger)
+    logger.child = (bindings, options): any => {
+      const childFormatters = options?.formatters as LoggerOptions['formatters']
+      const childLogger: Logger = child(bindings, {
+        ...options,
+        formatters: {
+          ...childFormatters,
+          log: createLogWithContext(() => childLogger.bindings(), childFormatters?.log)
+        }
+      })
+      return childLogger
+    }
+  }
+
+  return logger
 }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,0 +1,41 @@
+import { Obj, pipe } from '@apoyo/std'
+import pino, { LoggerOptions as PinoOptions } from 'pino'
+import pinoPretty from 'pino-pretty'
+
+import { LoggerOptions } from './config'
+import { LoggerContext } from './context'
+
+export function createLogger(config: LoggerOptions, context?: LoggerContext) {
+  const prettyEnabled = config.prettyPrint === false ? false : config.prettyPrint
+
+  const prettyConfig = typeof config.prettyPrint === 'boolean' ? {} : config.prettyPrint
+
+  const out = config.destination ?? process.stdout
+  const stream = prettyEnabled
+    ? pinoPretty({
+        colorize: true,
+        translateTime: true,
+        ignore: 'pid,hostname',
+        ...prettyConfig,
+        destination: out
+      })
+    : out
+
+  const mixin: PinoOptions['mixin'] = () => {
+    const bindings = context?.bindings()
+    return {
+      ...bindings
+    }
+  }
+
+  const configWithoutPretty = pipe(config, Obj.omit(['prettyPrint']))
+
+  const options: PinoOptions = {
+    ...configWithoutPretty,
+    enabled: config.enabled ?? true,
+    level: config.level ?? 'info',
+    mixin
+  }
+
+  return pino(options, stream)
+}

--- a/packages/logger/tests/logger-context.spec.ts
+++ b/packages/logger/tests/logger-context.spec.ts
@@ -1,0 +1,90 @@
+import { PassThrough } from 'stream'
+import { createLogger, LoggerContext, LogLevel } from '../src'
+
+const mockStdout = (fn: (str: string) => any) => {
+  const passthrough = new PassThrough()
+  const stdout = jest.fn()
+  passthrough.on('data', (data: Buffer) => {
+    const str = data.toString('utf8')
+    stdout(fn(str))
+  })
+
+  return {
+    passthrough,
+    stdout
+  }
+}
+
+describe('LoggerContext', () => {
+  it('should add additional information to each logger in async scope', async () => {
+    const { stdout, passthrough } = mockStdout((str) => JSON.parse(str))
+
+    const context = new LoggerContext()
+    const logger = createLogger(
+      {
+        destination: passthrough
+      },
+      context
+    )
+
+    const reqLogger = logger.child({
+      req: {
+        id: 'xxxx-xxxx-xxxx',
+        method: 'GET',
+        ip: '192.168.0.0'
+      }
+    })
+
+    await context.attachBindings(reqLogger.bindings(), async () => {
+      const contextBindings = context.bindings()
+
+      expect(contextBindings).toEqual({
+        req: expect.objectContaining({
+          id: expect.any(String)
+        })
+      })
+
+      logger.info(
+        {
+          foo: 'bar'
+        },
+        'Info'
+      )
+
+      expect(stdout).toBeCalledTimes(1)
+
+      const log = stdout.mock.calls[0][0]
+      expect(log).toEqual(
+        expect.objectContaining({
+          level: logger.levels.values[LogLevel.INFO],
+          msg: 'Info',
+          foo: 'bar',
+          req: expect.objectContaining({
+            id: expect.anything()
+          })
+        })
+      )
+    })
+
+    stdout.mockReset()
+
+    logger.info(
+      {
+        foo: 'bar'
+      },
+      'Info'
+    )
+
+    expect(stdout).toBeCalledTimes(1)
+
+    const log = stdout.mock.calls[0][0]
+    expect(log.req).toBe(undefined)
+    expect(log).toEqual(
+      expect.objectContaining({
+        level: logger.levels.values[LogLevel.INFO],
+        msg: 'Info',
+        foo: 'bar'
+      })
+    )
+  })
+})

--- a/packages/logger/tests/logger-context.spec.ts
+++ b/packages/logger/tests/logger-context.spec.ts
@@ -27,7 +27,14 @@ describe('LoggerContext', () => {
       context
     )
 
+    const featureLogger = logger.child({
+      name: 'MyFeature',
+      hello: 'John'
+    })
+
     const reqLogger = logger.child({
+      name: 'Http',
+      hello: 'Doe',
       req: {
         id: 'xxxx-xxxx-xxxx',
         method: 'GET',
@@ -39,12 +46,14 @@ describe('LoggerContext', () => {
       const contextBindings = context.bindings()
 
       expect(contextBindings).toEqual({
+        name: 'Http',
+        hello: 'Doe',
         req: expect.objectContaining({
           id: expect.any(String)
         })
       })
 
-      logger.info(
+      featureLogger.info(
         {
           foo: 'bar'
         },
@@ -56,9 +65,11 @@ describe('LoggerContext', () => {
       const log = stdout.mock.calls[0][0]
       expect(log).toEqual(
         expect.objectContaining({
+          name: 'MyFeature',
           level: logger.levels.values[LogLevel.INFO],
           msg: 'Info',
           foo: 'bar',
+          hello: 'John',
           req: expect.objectContaining({
             id: expect.anything()
           })

--- a/packages/logger/tests/logger.spec.ts
+++ b/packages/logger/tests/logger.spec.ts
@@ -1,0 +1,75 @@
+import { PassThrough } from 'stream'
+import { createLogger, LogLevel } from '../src'
+
+const mockStdout = (fn: (str: string) => any) => {
+  const passthrough = new PassThrough()
+  const stdout = jest.fn()
+  passthrough.on('data', (data: Buffer) => {
+    const str = data.toString('utf8')
+    stdout(fn(str))
+  })
+
+  return {
+    passthrough,
+    stdout
+  }
+}
+
+const stripAnsi = (str: string) =>
+  str.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+
+describe('createLogger', () => {
+  it('should not use pretty print by default', async () => {
+    const { stdout, passthrough } = mockStdout((str) => JSON.parse(str))
+
+    const logger = createLogger({
+      destination: passthrough
+    })
+
+    logger.debug('Debug')
+
+    expect(stdout).toBeCalledTimes(0)
+
+    logger.info(
+      {
+        foo: 'bar'
+      },
+      'Info'
+    )
+
+    expect(stdout).toBeCalledTimes(1)
+
+    const log = stdout.mock.calls[0][0]
+    expect(log.name).toBe(undefined)
+    expect(log).toEqual(
+      expect.objectContaining({
+        level: logger.levels.values[LogLevel.INFO],
+        msg: 'Info',
+        foo: 'bar'
+      })
+    )
+  })
+
+  it('should use pretty print when enabled', async () => {
+    const { stdout, passthrough } = mockStdout((str) => stripAnsi(str))
+
+    const logger = createLogger({
+      prettyPrint: true,
+      destination: passthrough
+    })
+
+    logger.debug('Debug')
+
+    expect(stdout).toBeCalledTimes(0)
+
+    logger.info(
+      {
+        foo: 'bar'
+      },
+      'Info'
+    )
+
+    expect(stdout).toBeCalledTimes(1)
+    expect(stdout.mock.calls[0][0]).toEqual(expect.stringContaining('INFO: Info'))
+  })
+})

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "baseUrl": "."
+  }
+}

--- a/packages/logger/tsup.config.ts
+++ b/packages/logger/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  splitting: false,
+  sourcemap: false,
+  dts: true,
+  clean: true,
+  minify: false,
+  format: ['cjs', 'esm']
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@apoyo/logger@workspace:packages/logger":
+  version: 0.0.0-use.local
+  resolution: "@apoyo/logger@workspace:packages/logger"
+  dependencies:
+    "@apoyo/std": ^0.0.15
+    "@types/jest": ^26.0.23
+    "@types/node": ^16.18.0
+    jest: ^26.4.2
+    pino: ^8.7.0
+    pino-pretty: ^9.1.1
+    ts-jest: ^26.3.0
+    ts-node: ^8.0.2
+    tsup: ^6.1.2
+    typescript: ^4.7.4
+  peerDependencies:
+    "@apoyo/std": ^0.0.15
+  languageName: unknown
+  linkType: soft
+
 "@apoyo/policies@workspace:packages/policies":
   version: 0.0.0-use.local
   resolution: "@apoyo/policies@workspace:packages/policies"


### PR DESCRIPTION
**Features**:

Split up the `@apoyo/process` package into 2 framework agnostic packages: `@apoyo/logger` and `@apoyo/config`. The logger and configuration code will be removed from `@apoyo/process` package after these 2 packages have been released.

This PR contains the `@apoyo/logger` package, which wraps the `pino` and `pino-pretty` library, and adds better support of `AsyncLocalStorage` context.